### PR TITLE
Respect no_proxy environment variable for https

### DIFF
--- a/ext/html/html.go
+++ b/ext/html/html.go
@@ -3,8 +3,8 @@ package goproxy_html
 
 import (
 	"bytes"
-	"code.google.com/p/go-charset/charset"
-	_ "code.google.com/p/go-charset/data"
+	"github.com/rogpeppe/go-charset/charset"
+	_ "github.com/rogpeppe/go-charset/data"
 	"errors"
 	"github.com/elazarl/goproxy"
 	"io"

--- a/https.go
+++ b/https.go
@@ -7,10 +7,11 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
+
+	"golang.org/x/net/http/httpproxy"
 )
 
 type ConnectActionLiteral int
@@ -39,6 +40,22 @@ func stripPort(s string) string {
 		return s
 	}
 	return s[:ix]
+}
+
+func httpsProxyFromEnv(reqURL *url.URL) (string, error) {
+	cfg := httpproxy.FromEnvironment()
+	// We only use this codepath for HTTPS CONNECT proxies so we shouldn't
+	// return anything from HTTPProxy
+	cfg.HTTPProxy = ""
+
+	proxyURL, err := cfg.ProxyFunc()(reqURL)
+	if err != nil {
+		return "", err
+	}
+	if proxyURL != nil {
+		return proxyURL.String(), nil
+	}
+	return "", nil
 }
 
 func (proxy *ProxyHttpServer) dial(network, addr string, userdata interface{}) (c net.Conn, err error) {
@@ -76,9 +93,9 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		if !hasPort.MatchString(host) {
 			host += ":80"
 		}
-		https_proxy := os.Getenv("https_proxy")
-		if https_proxy == "" {
-			https_proxy = os.Getenv("HTTPS_PROXY")
+		https_proxy, err := httpsProxyFromEnv(r.URL)
+		if err != nil {
+			ctx.Warnf("Error configuring HTTPS proxy: %s", err)
 		}
 		var targetSiteCon net.Conn
 		var e error

--- a/https.go
+++ b/https.go
@@ -3,6 +3,7 @@ package goproxy
 import (
 	"bufio"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -52,10 +53,16 @@ func httpsProxyFromEnv(reqURL *url.URL) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if proxyURL != nil {
-		return proxyURL.String(), nil
+	if proxyURL == nil {
+		return "", nil
 	}
-	return "", nil
+
+	service := proxyURL.Port()
+	if service == "" {
+		service = proxyURL.Scheme
+	}
+
+	return fmt.Sprintf("%s:%s", proxyURL.Hostname(), service), nil
 }
 
 func (proxy *ProxyHttpServer) dial(network, addr string, userdata interface{}) (c net.Conn, err error) {

--- a/https_test.go
+++ b/https_test.go
@@ -15,9 +15,10 @@ var proxytests = map[string]struct {
 	"never proxy http": {"", "daproxy", "http://foo.bar/baz", ""},
 
 	"do not proxy https without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
-	"proxy https with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "http://daproxy"},
-	"proxy https with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "https://daproxy"},
-	"proxy https with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "http://daproxy"},
+	"proxy https with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"proxy https with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
+	"proxy https with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
+	"proxy https with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
 	"do not proxy https with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
 	"do not proxy https with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
 }

--- a/https_test.go
+++ b/https_test.go
@@ -1,0 +1,62 @@
+package goproxy
+
+import (
+	"net/url"
+	"os"
+	"testing"
+)
+
+var proxytests = map[string]struct {
+	noProxy     string
+	httpsProxy  string
+	url         string
+	expectProxy string
+}{
+	"never proxy http": {"", "daproxy", "http://foo.bar/baz", ""},
+
+	"do not proxy https without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
+	"proxy https with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "http://daproxy"},
+	"proxy https with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "https://daproxy"},
+	"proxy https with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "http://daproxy"},
+	"do not proxy https with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
+	"do not proxy https with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
+}
+
+var envKeys = []string{"no_proxy", "http_proxy", "https_proxy", "NO_PROXY", "HTTP_PROXY", "HTTPS_PROXY"}
+
+func TestHttpsProxyFromEnv(t *testing.T) {
+	for _, k := range envKeys {
+		v, ok := os.LookupEnv(k)
+		if ok {
+			defer func() {
+				os.Setenv(k, v)
+			}()
+			os.Unsetenv(k)
+		} else {
+			defer func() {
+				os.Unsetenv(k)
+			}()
+		}
+	}
+	os.Setenv("http_proxy", "should.never.use.this")
+
+	for name, spec := range proxytests {
+		t.Run(name, func(t *testing.T) {
+			os.Setenv("no_proxy", spec.noProxy)
+			os.Setenv("https_proxy", spec.httpsProxy)
+
+			url, err := url.Parse(spec.url)
+			if err != nil {
+				t.Fatalf("bad test input URL %s: %v", spec.url, err)
+			}
+
+			actual, err := httpsProxyFromEnv(url)
+			if err != nil {
+				t.Fatalf("unexpected error parsing proxy from env: %#v", err)
+			}
+			if actual != spec.expectProxy {
+				t.Errorf("expected proxy url '%s' but got '%s'", spec.expectProxy, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
goproxy does not currently respect the no_proxy environment variable in relation to the https_proxy environment variable. This fixes the problem and rewrites some imports to make the project compile.

Several tests in the project are currently broken and I timed out trying to fix them. I added new tests for my own logic but did not attempt to make the overall build work.