### PR TITLE
Fix CONNECT proxying scheme

### DIFF
--- a/https.go
+++ b/https.go
@@ -49,7 +49,13 @@ func httpsProxyFromEnv(reqURL *url.URL) (string, error) {
 	// return anything from HTTPProxy
 	cfg.HTTPProxy = ""
 
-	proxyURL, err := cfg.ProxyFunc()(reqURL)
+	// The request URL provided to the proxy for a CONNECT request does
+	// not necessarily have an https scheme but ProxyFunc uses the scheme
+	// to determine which env var to introspect.
+	reqSchemeURL := reqURL
+	reqSchemeURL.Scheme = "https"
+
+	proxyURL, err := cfg.ProxyFunc()(reqSchemeURL)
 	if err != nil {
 		return "", err
 	}

--- a/https_test.go
+++ b/https_test.go
@@ -12,15 +12,14 @@ var proxytests = map[string]struct {
 	url         string
 	expectProxy string
 }{
-	"never proxy http": {"", "daproxy", "http://foo.bar/baz", ""},
-
-	"do not proxy https without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
-	"proxy https with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
-	"proxy https with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
-	"proxy https with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
-	"proxy https with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
-	"do not proxy https with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
-	"do not proxy https with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
+	"do not proxy without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
+	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "daproxy:http"},
+	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
+	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
+	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"do not proxy with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
+	"do not proxy with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
 }
 
 var envKeys = []string{"no_proxy", "http_proxy", "https_proxy", "NO_PROXY", "HTTP_PROXY", "HTTPS_PROXY"}


### PR DESCRIPTION
In testing my changes from #5 I discovered that httpsProxyFromEnv *never* returns a proxy URL because the request URL it gets does not contain a scheme. The httpproxy library we're using relies on the scheme to decide when to use the https_proxy environment variable. Since `httpsProxyFromEnv` is very specific to proxying CONNECT requests, I think it's reasonable to just hack in the correct scheme.

r? @rlk-stripe 