### PR TITLE
Add CONNECT handlers for custom client connection and copy implementations

### DIFF
--- a/https.go
+++ b/https.go
@@ -96,6 +96,10 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		panic("Cannot hijack connection " + e.Error())
 	}
 
+	if proxy.ConnectClientConnHandler != nil {
+		proxyClient = proxy.ConnectClientConnHandler(proxyClient)
+	}
+
 	ctx.Logf("Running %d CONNECT handlers", len(proxy.httpsHandlers))
 	todo, host := OkConnect, r.URL.Host
 	for i, h := range proxy.httpsHandlers {
@@ -133,7 +137,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		ctx.Logf("Accepting CONNECT to %s", host)
 		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
 
-		if proxy.CopyHandler != nil {
+		if proxy.ConnectCopyHandler != nil {
 			go proxy.CopyHandler(ctx, proxyClient, targetSiteCon)
 			return
 		}

--- a/https.go
+++ b/https.go
@@ -133,6 +133,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		ctx.Logf("Accepting CONNECT to %s", host)
 		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
 
+		if proxy.CopyHandler != nil {
+			go proxy.CopyHandler(ctx, proxyClient, targetSiteCon)
+			return
+		}
+
 		targetTCP, targetOK := targetSiteCon.(*net.TCPConn)
 		proxyClientTCP, clientOK := proxyClient.(*net.TCPConn)
 		if targetOK && clientOK {

--- a/https.go
+++ b/https.go
@@ -138,7 +138,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
 
 		if proxy.ConnectCopyHandler != nil {
-			go proxy.CopyHandler(ctx, proxyClient, targetSiteCon)
+			go proxy.ConnectCopyHandler(ctx, proxyClient, targetSiteCon)
 			return
 		}
 

--- a/proxy.go
+++ b/proxy.go
@@ -33,6 +33,10 @@ type ProxyHttpServer struct {
 	// ConnectDialContext will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
 	ConnectDialContext func(ctx *ProxyCtx, network string, addr string) (net.Conn, error)
+
+	// CopyHandler allows users to implement a custom copy routine when forwarding data
+	// between the proxy client and proxy target for CONNECT requests
+	CopyHandler func(ctx *ProxyCtx, client, target net.Conn)
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)

--- a/proxy.go
+++ b/proxy.go
@@ -34,9 +34,14 @@ type ProxyHttpServer struct {
 	// if nil Tr.Dial will be used
 	ConnectDialContext func(ctx *ProxyCtx, network string, addr string) (net.Conn, error)
 
-	// CopyHandler allows users to implement a custom copy routine when forwarding data
+	// ConnectCopyHandler allows users to implement a custom copy routine when forwarding data
 	// between the proxy client and proxy target for CONNECT requests
-	CopyHandler func(ctx *ProxyCtx, client, target net.Conn)
+	ConnectCopyHandler func(ctx *ProxyCtx, client, target net.Conn)
+
+	// ConnectClientConnHandler allows users to set a callback function which gets passed
+	// the hijacked proxy client net.Conn. This is useful for wrapping the connection
+	// to implement timeouts or additional tracing.
+	ConnectClientConnHandler func(net.Conn) net.Conn
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)


### PR DESCRIPTION
This adds support for defining two new custom handlers for CONNECT request behavior.

* `ConnectClientConnHandler` allows users to define a callback for wrapping CONNECT client connections with custom behavior. In our case we use it to add timeouts to the hijacked `net.Conn`.
* `ConnectCopyHandler` allows users to implement their own copy routine to forward data between the proxy client and proxy target. We will use this to emit metrics for connection timeouts.

r? @ransford-stripe 
cc @stripe/platform-security 