### PR TITLE
allow specifying a custom http error handler

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"io"
 	"net/http"
 	"regexp"
 )
@@ -15,6 +16,9 @@ type ProxyCtx struct {
 	RoundTripper RoundTripper
 	// will contain the recent error that occurred while trying to send receive or parse traffic
 	Error error
+	// Will be invoked to return a custom response to clients when goproxy fails to connect
+	// to a proxy target
+	HTTPErrorHandler func(io.WriteCloser, *ProxyCtx, error)
 	// A handle for the user to keep data in the context, from the call of ReqHandler to the
 	// call of RespHandler
 	UserData interface{}

--- a/https.go
+++ b/https.go
@@ -318,6 +318,10 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 }
 
 func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {
+	if ctx.HTTPErrorHandler != nil {
+		ctx.HTTPErrorHandler(w, ctx, err)
+		return
+	}
 	if _, err := io.WriteString(w, "HTTP/1.1 502 Bad Gateway\r\n\r\n"); err != nil {
 		ctx.Warnf("Error responding to client: %s", err)
 	}


### PR DESCRIPTION
This PR allows us to return a custom response when the proxy fails to connect to the remote host. More specifically, this is required for us to return anything besides a bare 502 response for failed CONNECT requests. This is necessary for proxies who need to set a custom HTTP status code, set specific HTTP headers, or want to place a more informative error message in the response's body. 

The way the request chaining works with traditional HTTP requests allows us to identify the error and return an appropriate response. https://github.com/stripe/goproxy/blob/master/proxy.go#L133

r? @rwg-stripe 
cc @stripe/platform-security 