### PR TITLE
add connection error callbacks

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -19,6 +19,8 @@ type ProxyCtx struct {
 	// Will be invoked to return a custom response to clients when goproxy fails to connect
 	// to a proxy target
 	HTTPErrorHandler func(io.WriteCloser, *ProxyCtx, error)
+	// Used to pass back errors returned during calls to copyAndWarn() for TLS CONNECT requests
+	ConnErrorHandler func(error)
 	// A handle for the user to keep data in the context, from the call of ReqHandler to the
 	// call of RespHandler
 	UserData interface{}

--- a/https.go
+++ b/https.go
@@ -152,6 +152,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				var err error
 				var wg sync.WaitGroup
 				wg.Add(2)
+				// Only capture an error from one of the calls to copyOrWarn.
+				// copyOrWarn() is called twice with the same net.Conn pair with
+				// the src and dst parameters inverted. When the connection is
+				// terminated prematurely the net.Error type is the same, but
+				// the directionality of the Error() message changes.
 				go func() {
 					err = copyOrWarn(ctx, targetSiteCon, proxyClient)
 					wg.Done()


### PR DESCRIPTION
This PR adds support for specifying a customer error handler which is called in the event there is an error in the copy routine between the proxy client and target host. This is needed to surface `net.Conn` errors encountered during the connection's lifetime. As an example, the proxy implementation will now be able to determine if a connection was closed due to a timeout.

These changes were only applied to `copyOrWarn` because in my testing, I've not encountered any HTTP clients which use the CONNECT protocol for non-TLS connections. `targetSiteCon` and `proxyClient` always unwrap to a `tls.Conn`, and thus fallthrough to use `copyOrWarn` over `copyAndClose`.

We are only capturing an error from one of the calls to `copyOrWarn`. The function is called twice with the same `net.Conn` pair with the src and dst parameters inverted. When the connection is terminated prematurely the `net.Error` type is the same, but the directionality of the `Error()` message changes.

I also lifted the calls to `wg.Done()` to avoid a race condition where prematurely checking the returned error could cause the custom error handler to not be invoked.

I've integrated and tested this with Smokescreen on here https://github.com/stripe/smokescreen/tree/cds/timeout-obs/pkg/smokescreen.

r? @rwg-stripe 
cc @stripe/platform-security 