### PR TITLE
fix go vet issues

### DIFF
--- a/https.go
+++ b/https.go
@@ -452,7 +452,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 
 func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 	return func(host string, ctx *ProxyCtx) (*tls.Config, error) {
-		config := *defaultTLSConfig
+		config := defaultTLSConfig.Clone()
 		ctx.Logf("signing for %s", stripPort(host))
 		cert, err := signHost(*ca, []string{stripPort(host)})
 		if err != nil {
@@ -460,7 +460,7 @@ func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls
 			return nil, err
 		}
 		config.Certificates = append(config.Certificates, cert)
-		return &config, nil
+		return config, nil
 	}
 }
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -504,8 +504,7 @@ func constantHttpServer(content []byte) (addr string) {
 
 func TestIcyResponse(t *testing.T) {
 	// TODO: fix this test
-	return // skip for now
-	s := constantHttpServer([]byte("ICY 200 OK\r\n\r\nblablabla"))
+	/*s := constantHttpServer([]byte("ICY 200 OK\r\n\r\nblablabla"))
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = true
 	_, l := oneShotProxy(proxy, t)
@@ -522,7 +521,7 @@ func TestIcyResponse(t *testing.T) {
 	panicOnErr(err, "readAll")
 	if string(raw) != "ICY 200 OK\r\n\r\nblablabla" {
 		t.Error("Proxy did not send the malformed response received")
-	}
+	}*/
 }
 
 type VerifyNoProxyHeaders struct {


### PR DESCRIPTION
We are now running `go vet` checks in Gocode and this code is failing. bartle already submitted this to the upstream goproxy repository here https://github.com/elazarl/goproxy/pull/370.

r? @hans-stripe 
cc @stripe/platform-security 