### PR TITLE
Inject custom round tripper into ProxyContext during ConnectMitm

### DIFF
--- a/https.go
+++ b/https.go
@@ -243,7 +243,9 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			clientTlsReader := bufio.NewReader(rawClientTls)
 			for !isEof(clientTlsReader) {
 				req, err := http.ReadRequest(clientTlsReader)
-				var ctx = &ProxyCtx{Req: req, Session: atomic.AddInt64(&proxy.sess, 1), proxy: proxy, UserData: ctx.UserData}
+				// Set the RoundTripper on the ProxyCtx within the `HandleConnect` action of goproxy, then
+				// inject the roundtripper here in order to use a custom round tripper while mitm.
+				var ctx = &ProxyCtx{Req: req, Session: atomic.AddInt64(&proxy.sess, 1), proxy: proxy, UserData: ctx.UserData, RoundTripper: ctx.RoundTripper}
 				if err != nil && err != io.EOF {
 					return
 				}


### PR DESCRIPTION
## Summary
This change ensures the `ctx.RoundTripper` is set on the new ctx during ConnectMitm. This is important because we can set the RoundTripper when we define the `HandleConnect` action on goproxy, and can define a custom roundtripper to, for example, have custom transports / hostname.

The Roundtripper comes up here, https://github.com/stripe/goproxy/blob/9fe3aa7354aa26d9a5572378724d75b5fae83567/https.go#L274, when calling `ctx.RoundTrip`. If you trace the function call, https://github.com/stripe/goproxy/blob/9fe3aa7354aa26d9a5572378724d75b5fae83567/ctx.go#L42-L47, then when the RoundTripper is nil, things fall through to the proxy.Tr. But when not-nil, we use our custom RoundTripper. Therefore - this doesn't change any behavior unless one sets the RoundTripper in HandleConnect.

Also, by setting this on the request level (on the ctx), we avoid needing to do anything with Mutex/swapping out the `proxy.Tr`.

## Reviewers
r? @shawn-stripe 
cc? @karla-stripe