### PR TITLE
ignore used of closed network conn error

### DIFF
--- a/https.go
+++ b/https.go
@@ -164,7 +164,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			// the client.
 			go func() {
 				err := copyOrWarn(ctx, targetSiteCon, proxyClient)
-				if err != nil && ctx.ConnErrorHandler != nil {
+				if err != nil && ctx.ConnErrorHandler != nil && !isClosedNetworkConnError(err) {
 					ctx.ConnErrorHandler(err)
 				}
 				targetSiteCon.Close()
@@ -347,9 +347,13 @@ func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {
 	}
 }
 
+func isClosedNetworkConnError(err error) bool {
+	return strings.HasSuffix(err.Error(), "use of closed network connection")
+}
+
 func copyOrWarn(ctx *ProxyCtx, dst io.Writer, src io.Reader) error {
 	_, err := io.Copy(dst, src)
-	if err != nil {
+	if err != nil && !isClosedNetworkConnError(err) {
 		ctx.Warnf("Error copying to client: %s", err)
 	}
 	return err

--- a/https.go
+++ b/https.go
@@ -347,6 +347,8 @@ func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {
 	}
 }
 
+// isClosedNetworkConnError returns true if the error contains the suffix "use of closed network connection".
+// This isn't ideal, and in Go 1.16 we will be able to check for net.ErrClosed.
 func isClosedNetworkConnError(err error) bool {
 	return strings.HasSuffix(err.Error(), "use of closed network connection")
 }


### PR DESCRIPTION
This PR only logs errors if the error returned from `io.Copy` is not `use of closed network connection`.

This is creating FUD in the `CANONICAL-PROXY-CN-CLOSE` log lines, and making it hard to diagnose actual errors in our build logs. As we're not able to synchronize the closing of the connections, these errors are unavoidable and from everything I've experienced and read, totally benign.

r? @hans-stripe 
cc @stripe/platform-security 