### PR TITLE
Fixing bug in upstream https proxy configuration

### DIFF
--- a/https.go
+++ b/https.go
@@ -494,7 +494,7 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 		return nil, err
 	}
 
-	c, err := proxy.connectDialContext(ctx, "tcp", proxyHost)
+	c, err := proxy.connectDialContext(ctx, "tcp", proxyURL.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -555,8 +555,10 @@ func httpsProxyFromEnv(reqURL *url.URL) (string, error) {
 
 	service := proxyURL.Port()
 	if service == "" {
+		// TODO I am very confused by this line of code
+		// what does a URL of the form `proxy-example.com:http` mean??
 		service = proxyURL.Scheme
 	}
 
-	return fmt.Sprintf("%s:%s", proxyURL.Hostname(), service), nil
+	return fmt.Sprintf("//%s:%s", proxyURL.Hostname(), service), nil
 }

--- a/https_test.go
+++ b/https_test.go
@@ -12,13 +12,12 @@ var proxytests = map[string]struct {
 	url         string
 	expectProxy string
 }{
-	// TODO confused by the tests. Why is the scheme where the port number supposed to be?
 	"do not proxy without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
-	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "//daproxy:http"},
-	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "//daproxy:http"},
-	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "//daproxy:123"},
-	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "//daproxy:https"},
-	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "//daproxy:http"},
+	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "daproxy:http"},
+	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
+	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
+	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
 	"do not proxy with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
 	"do not proxy with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
 }

--- a/https_test.go
+++ b/https_test.go
@@ -13,11 +13,11 @@ var proxytests = map[string]struct {
 	expectProxy string
 }{
 	"do not proxy without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
-	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
-	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "daproxy:http"},
-	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
-	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
-	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "http://daproxy:http"},
+	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "http://daproxy:http"},
+	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "http://daproxy:123"},
+	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "https://daproxy:https"},
+	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "http://daproxy:http"},
 	"do not proxy with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
 	"do not proxy with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
 }

--- a/https_test.go
+++ b/https_test.go
@@ -12,12 +12,13 @@ var proxytests = map[string]struct {
 	url         string
 	expectProxy string
 }{
+	// TODO confused by the tests. Why is the scheme where the port number supposed to be?
 	"do not proxy without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
-	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
-	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "daproxy:http"},
-	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
-	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
-	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "//daproxy:http"},
+	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "//daproxy:http"},
+	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "//daproxy:123"},
+	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "//daproxy:https"},
+	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "//daproxy:http"},
 	"do not proxy with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
 	"do not proxy with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
 }


### PR DESCRIPTION
👋 Hello! An error encountered while using [smokescreen](https://github.com/stripe/smokescreen) brought me here.

I was trying to configure smokescreen so that it forwards requests to another upstream proxy:
```
$ HTTP_PROXY=http://10.0.0.1:9999 HTTPS_PROXY=http://10.0.0.1:9999 ./smokescreen --allow-range 10.0.0.1/32
```
That invocation works for http urls, but gives this error for https urls:
```
 level":"error","msg":"Failed to connect to remote host: parse \"192.168.0.12:9999\": first path segment in URL cannot contain colon"
```
This error originates in the goproxy code base, specifically here: https://github.com/stripe/goproxy/blob/master/https.go#L492

The main two problems seem to be:
* `httpsProxyFromEnv` does not return a URL that is parsable by `url.Parse`
* The subsequent call to `proxy.connectDialContext` passes the full URL, when it expects just a host.

This PR fixes those two issue. Also, I was a bit confused by another part of the `httpsProxyFromEnv` function and corresponding tests. I left a few comments about that as well, but will delete before merging.

Thanks!