### PR TITLE
limit response size from upstream proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/https.go
+++ b/https.go
@@ -420,7 +420,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
-				resp, err := ioutil.ReadAll(resp.Body)
+				resp, err := ioutil.ReadAll(io.LimitReader(resp.Body, 500))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
This prevents a potentially malicious upstream proxy from sending an unbounded response which would DoS the process running this instance of `goproxy`. This is identical to what was done upstream https://github.com/elazarl/goproxy/blob/master/https.go#L411. Not sure how this didn't merge cleanly originally.

r? @jjiang-stripe 