### PR TITLE
Add hook to successful connect response

### DIFF
--- a/https.go
+++ b/https.go
@@ -2,6 +2,7 @@ package goproxy
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -177,7 +178,18 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 
 	case ConnectHijack:
 		ctx.Logf("Hijacking CONNECT to %s", host)
-		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+		respBytes, err := createCustomConnectResponse(ctx)
+		if respBytes != nil {
+			// Write the custom response, if one was returned
+			proxyClient.Write(respBytes)
+		} else {
+			// Otherwise, log any errors and fallback to the default response
+			if err != nil {
+				ctx.Warnf("Error writing custom CONNECT response: %s", err.Error())
+				return
+			}
+			proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+		}
 		todo.Hijack(r, proxyClient, ctx)
 	case ConnectHTTPMitm:
 		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
@@ -332,6 +344,22 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		}
 		proxyClient.Close()
 	}
+}
+
+func createCustomConnectResponse(ctx *ProxyCtx) ([]byte, error) {
+	if ctx.proxy.ConnectRespHandler == nil {
+		return nil, nil
+	}
+	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", Header: http.Header{}}
+	err := ctx.proxy.ConnectRespHandler(ctx, resp)
+	if err != nil {
+		return nil, err
+	}
+	buf := &bytes.Buffer{}
+	if err := resp.Write(buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {

--- a/https.go
+++ b/https.go
@@ -189,18 +189,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 
 	case ConnectHijack:
 		ctx.Logf("Hijacking CONNECT to %s", host)
-		respBytes, err := createCustomConnectResponse(ctx)
-		if respBytes != nil {
-			// Write the custom response, if one was returned
-			proxyClient.Write(respBytes)
-		} else {
-			// Otherwise, log any errors and fallback to the default response
-			if err != nil {
-				ctx.Warnf("Error writing custom CONNECT response: %s", err.Error())
-				return
-			}
-			proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
-		}
+		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
 		todo.Hijack(r, proxyClient, ctx)
 	case ConnectHTTPMitm:
 		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))

--- a/proxy.go
+++ b/proxy.go
@@ -50,6 +50,10 @@ type ProxyHttpServer struct {
 	// the hijacked proxy client net.Conn. This is useful for wrapping the connection
 	// to implement timeouts or additional tracing.
 	ConnectClientConnHandler func(net.Conn) net.Conn
+
+	// ConnectRespHandler allows users to mutate the response to the CONNECT request before it
+	// is returned to the client.
+	ConnectRespHandler func(ctx *ProxyCtx, resp *http.Response) error
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)


### PR DESCRIPTION
Provides a hook to allow for custom modifications to the 200 CONNECT response, such as adding a header.

I've opted to simply add a function to the proxy config rather than try to fit this functionality into the actions.go OnRequest/OnResponse framework; since CONNECT requests already have special-case fields such as ConnectCopyHandler and ConnectDialContext, this seems reasonable and also avoids additional complexity or modifications to existing logic.