### PR TITLE
Allow for setting basic auth in custom proxy

### DIFF
--- a/https.go
+++ b/https.go
@@ -605,5 +605,8 @@ func httpsProxyAddr(reqURL *url.URL, httpsProxy string) (string, error) {
 		service = proxyURL.Scheme
 	}
 
+	if proxyURL.User != nil {
+		return fmt.Sprintf("%s://%s@%s:%s", proxyURL.Scheme, proxyURL.User.String(), proxyURL.Hostname(), service), nil
+	}
 	return fmt.Sprintf("%s://%s:%s", proxyURL.Scheme, proxyURL.Hostname(), service), nil
 }

--- a/https_test.go
+++ b/https_test.go
@@ -13,15 +13,16 @@ var proxytests = map[string]struct {
 	url              string
 	expectProxy      string
 }{
-	"do not proxy without a proxy configured":   {"", "", "", "https://foo.bar/baz", ""},
-	"proxy with a proxy configured":             {"", "daproxy", "", "https://foo.bar/baz", "http://daproxy:http"},
-	"proxy without a scheme":                    {"", "daproxy", "", "//foo.bar/baz", "http://daproxy:http"},
-	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "", "https://foo.bar/baz", "http://daproxy:123"},
-	"proxy with an https proxy configured":      {"", "https://daproxy", "", "https://foo.bar/baz", "https://daproxy:https"},
-	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "", "https://foo.bar/baz", "http://daproxy:http"},
-	"do not proxy with a full no_proxy match":   {"foo.bar", "daproxy", "", "https://foo.bar/baz", ""},
-	"do not proxy with a suffix no_proxy match": {".bar", "daproxy", "", "https://foo.bar/baz", ""},
-	"proxy with an custom https proxy":          {"", "https://daproxy", "https://customproxy", "https://foo.bar/baz", "https://customproxy:https"},
+	"do not proxy without a proxy configured":          {"", "", "", "https://foo.bar/baz", ""},
+	"proxy with a proxy configured":                    {"", "daproxy", "", "https://foo.bar/baz", "http://daproxy:http"},
+	"proxy without a scheme":                           {"", "daproxy", "", "//foo.bar/baz", "http://daproxy:http"},
+	"proxy with a proxy configured with a port":        {"", "http://daproxy:123", "", "https://foo.bar/baz", "http://daproxy:123"},
+	"proxy with an https proxy configured":             {"", "https://daproxy", "", "https://foo.bar/baz", "https://daproxy:https"},
+	"proxy with a non-matching no_proxy":               {"other.bar", "daproxy", "", "https://foo.bar/baz", "http://daproxy:http"},
+	"do not proxy with a full no_proxy match":          {"foo.bar", "daproxy", "", "https://foo.bar/baz", ""},
+	"do not proxy with a suffix no_proxy match":        {".bar", "daproxy", "", "https://foo.bar/baz", ""},
+	"proxy with an custom https proxy":                 {"", "https://daproxy", "https://customproxy", "https://foo.bar/baz", "https://customproxy:https"},
+	"proxy with an custom https proxy with basic auth": {"", "https://daproxy", "https://user:password@customproxy", "https://foo.bar/baz", "https://user:password@customproxy:https"},
 }
 
 var envKeys = []string{"no_proxy", "http_proxy", "https_proxy", "NO_PROXY", "HTTP_PROXY", "HTTPS_PROXY"}


### PR DESCRIPTION
This allows a user to specify basic auth credentials when setting a custom proxy.