### PR TITLE
Add Proxy-Authorization header support for URL encoded credentials on HTTPS Requests

### DIFF
--- a/https.go
+++ b/https.go
@@ -617,7 +617,7 @@ func httpsProxyAddr(reqURL *url.URL, httpsProxy string) (string, error) {
 	}
 
 	hostname := proxyURL.Hostname()
-	if proxyURL.User.String() != "" {
+	if proxyURL.User != nil && proxyURL.User.String() != "" {
 		hostname = proxyURL.User.String() + "@" + hostname
 	}
 

--- a/https.go
+++ b/https.go
@@ -544,19 +544,21 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 		c = tls.Client(c, proxy.Tr.TLSClientConfig)
 	}
 
-	hdr := make(http.Header)
+	connectRequestHeaders := make(http.Header)
 
-	// Add proxy authentication header if needed
-	auth := proxyURL.User.String()
-	if auth != "" {
-		hdr.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
+	// Add authentication header if needed to the CONNECT request to the proxy
+	user := proxyURL.User
+	if user != nil {
+		if auth := user.String(); auth != "" {
+			connectRequestHeaders.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
+		}
 	}
 
 	connectReq := &http.Request{
 		Method: "CONNECT",
 		URL:    &url.URL{Opaque: host},
 		Host:   host,
-		Header: hdr,
+		Header: connectRequestHeaders,
 	}
 	connectReq.Write(c)
 	// Read response.

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -750,7 +750,12 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 
 	fakeExternalProxy := goproxy.NewProxyHttpServer()
 	fakeExternalProxyTestStruct := httptest.NewServer(fakeExternalProxy)
-	fakeExternalProxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+	var AlwaysMitmAndPassthrough goproxy.FuncHttpsHandler = func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+		// TODO: make this test use the X-Https-Upstream-Proxy header and parse it out here to make sure it's set and passed through
+		//  to the authorization header
+		return goproxy.MitmConnect, host
+	}
+	fakeExternalProxy.OnRequest().HandleConnect(AlwaysMitmAndPassthrough)
 	tagExternalProxyPassthrough := func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 		b, err := ioutil.ReadAll(resp.Body)
 		panicOnErr(err, "readAll resp")


### PR DESCRIPTION
## Summary
This PR adds support for passing the `Proxy-Authorization` header into the `CONNECT` request from GoProxy to an external proxy. 

## Testing

1. Existing tests pass 
2. Rolled this out to QA 

