### PR TITLE
Add a mitmMutateRequest hook and add ConnectAction to ProxyCtx

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -25,8 +25,9 @@ type ProxyCtx struct {
 	// call of RespHandler
 	UserData interface{}
 	// Will connect a request to a response
-	Session int64
-	proxy   *ProxyHttpServer
+	Session       int64
+	proxy         *ProxyHttpServer
+	ConnectAction ConnectActionLiteral
 }
 
 type RoundTripper interface {


### PR DESCRIPTION
This PR adds 2 things

- A hook that enables the caller code to mutate the request via a hook. I've tested this working on smokescreen and added a test.
- Setting `ConnectAction` in `ProxyCtx`. `proxy.OnRequest().DoFunc` is called on the MITM request (the outbound one from `goproxy` to the remote host)  and adding this variable makes it easy to know if target is a "traditional" HTTP Proxy of if the MITM request.