### PR TITLE
Fix custom Connect response for Connect Request

### DIFF
--- a/https.go
+++ b/https.go
@@ -362,7 +362,7 @@ func createCustomConnectResponse(ctx *ProxyCtx) ([]byte, error) {
 	if ctx.proxy.ConnectRespHandler == nil {
 		return nil, nil
 	}
-	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", Header: http.Header{}}
+	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", ProtoMajor: 1, ProtoMinor: 0, Header: http.Header{}}
 	err := ctx.proxy.ConnectRespHandler(ctx, resp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary 
BUG - Go proxy creates HTTP/0.0 response instead of HTTP/1.0 while creating custom response. 
Missed setting protoMajor and protoMinor in response object
```
	Status     string // e.g. "200 OK"
	StatusCode int    // e.g. 200
	Proto      string // e.g. "HTTP/1.0"
	ProtoMajor int    // e.g. 1
	ProtoMinor int    // e.g. 0
```
These changes only apply to ConnectAccept requests
