### PR TITLE
Remove Content-Length from HTTP Connect Custom response 

### DIFF
--- a/https.go
+++ b/https.go
@@ -362,7 +362,7 @@ func createCustomConnectResponse(ctx *ProxyCtx) ([]byte, error) {
 	if ctx.proxy.ConnectRespHandler == nil {
 		return nil, nil
 	}
-	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", ProtoMajor: 1, ProtoMinor: 0, Header: http.Header{}}
+	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", ProtoMajor: 1, ProtoMinor: 0, ContentLength: -1, Header: http.Header{}}
 	err := ctx.proxy.ConnectRespHandler(ctx, resp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Summary 
Currently while using HTTP Connect custom handlers it responds with content-length as 0 along with HTTP/1.0 200 OK. This is not RFC-9110 compliant which states that a server MUST NOT send any Transfer-Encoding or Content-Length header fields in a 2xx (Successful) response to CONNECT.

Old HTTP Connect Custom Response 
```
HTTP/1.0 200 OK
Content-Length: 0
```

New HTTP Connect Custom Response 
```
HTTP/1.0 200 OK
```

### Changes 
We are setting ContentLength as -1 which marks it as unknown and removes content length while writing response

Snippet from Response Struct
```
// ContentLength records the length of the associated content. The
// value -1 indicates that the length is unknown. Unless Request.Method
// is "HEAD", values >= 0 indicate that the given number of bytes may
// be read from Body.
ContentLength int64
```