### PR TITLE
fix(sse): flush buffer for sse

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 	"sync/atomic"
 
 	"golang.org/x/net/http/httpproxy"
@@ -193,7 +194,8 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		copyHeaders(w.Header(), resp.Header, proxy.KeepDestinationHeaders)
 		w.WriteHeader(resp.StatusCode)
 		var copyWriter io.Writer = w
-		if w.Header().Get("content-type") == "text/event-stream" {
+		contentType := w.Header().Get("content-type")
+		if strings.Contains(contentType, "text/event-stream") {
 			// server-side events, flush the buffered data to the client.
 			copyWriter = &flushWriter{w: w}
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -133,6 +133,20 @@ func removeProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	r.Header.Del("Connection")
 }
 
+type flushWriter struct {
+	w io.Writer
+}
+
+func (fw flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	if f, ok := fw.w.(http.Flusher); ok {
+		// only flush if the Writer implements the Flusher interface.
+		f.Flush()
+	}
+
+	return n, err
+}
+
 // Standard net/http function. Shouldn't be used directly, http.Serve will use it.
 func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//r.Header["X-Forwarded-For"] = w.RemoteAddr()
@@ -178,7 +192,13 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 		copyHeaders(w.Header(), resp.Header, proxy.KeepDestinationHeaders)
 		w.WriteHeader(resp.StatusCode)
-		nr, err := io.Copy(w, resp.Body)
+		var copyWriter io.Writer = w
+		if w.Header().Get("content-type") == "text/event-stream" {
+			// server-side events, flush the buffered data to the client.
+			copyWriter = &flushWriter{w: w}
+		}
+
+		nr, err := io.Copy(copyWriter, resp.Body)
 		if err := resp.Body.Close(); err != nil {
 			ctx.Warnf("Can't close response body %v", err)
 		}
@@ -213,8 +233,8 @@ func WithHttpsProxyAddr(httpsProxyAddr string) ProxyHttpServerOptions {
 // NewProxyHttpServer creates and returns a proxy server, logging to stderr by default
 func NewProxyHttpServer(opts ...ProxyHttpServerOptions) *ProxyHttpServer {
 	appliedOpts := &options{
-		httpProxyAddr: "",
-		httpsProxyAddr:  "",
+		httpProxyAddr:  "",
+		httpsProxyAddr: "",
 	}
 	for _, opt := range opts {
 		opt.apply(appliedOpts)
@@ -245,7 +265,7 @@ func NewProxyHttpServer(opts ...ProxyHttpServerOptions) *ProxyHttpServer {
 	}
 
 	proxy.ConnectDial = dialerFromProxy(&proxy)
-	
+
 	if appliedOpts.httpProxyAddr != "" || appliedOpts.httpsProxyAddr != "" {
 		proxy.Tr.Proxy = func(req *http.Request) (*url.URL, error) {
 			return httpProxyCfg.ProxyFunc()(req.URL)


### PR DESCRIPTION
The goproxy don't flush the SSE buffer, which results in the HTTP client being unable to receive data immediately.

releated issuse: https://github.com/elazarl/goproxy/issues/475