### PR TITLE
Feature: Remote Server IP in CONNECT response headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.20.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -17,4 +17,4 @@ jobs:
     - name: Test
       run: |
         go mod verify
-        go test -mod=vendor ./...
+        go test -mod=vendor -v ./...

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ See additional examples in the examples directory.
 1. Ability to `Hijack` CONNECT requests. See
 [the eavesdropper example](https://github.com/elazarl/goproxy/blob/master/examples/goproxy-eavesdropper/main.go#L27)
 2. Transparent proxy support for http/https including MITM certificate generation for TLS.  See the [transparent example.](https://github.com/elazarl/goproxy/tree/master/examples/goproxy-transparent)
+3. Ability to extract remote server's IP in CONNECT response as `X-Server-Ip` Header. This can be used as specified below:
+```go
+proxy := goproxy.NewProxyHttpServer(goproxy.WithAddServerIpHeader(true))
+```
 
 # License
 

--- a/proxy_go120_test.go
+++ b/proxy_go120_test.go
@@ -1,0 +1,72 @@
+//go:build go1.20
+// +build go1.20
+
+package goproxy_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stripe/goproxy"
+)
+
+func TestAddServerIpHeader(t *testing.T) {
+	proxy := goproxy.NewProxyHttpServer(goproxy.WithAddServerIpHeader(true))
+	s := httptest.NewServer(proxy)
+	proxyUrl, _ := url.Parse(s.URL)
+
+	tr := &http.Transport{
+		OnProxyConnectResponse: func(ctx context.Context, proxyURL *url.URL, connectReq *http.Request, connectRes *http.Response) error {
+			if connectRes.Header.Get(goproxy.ServerIpHeaderKey) != "127.0.0.1" {
+				t.Errorf("Expected %s, got %s", "127.0.0.1", connectRes.Header.Get(goproxy.ServerIpHeaderKey))
+			}
+			return nil
+		},
+		Proxy:           http.ProxyURL(proxyUrl),
+		TLSClientConfig: acceptAllCerts,
+	}
+	client := &http.Client{Transport: tr}
+	if resp := string(getOrFail(https.URL+"/bobo", client, t)); resp != "bobo" {
+		t.Error("Wrong response when mitm", resp, "expected bobo")
+	}
+}
+
+func newIPv6TestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	server := httptest.NewUnstartedServer(handler)
+	l, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skip("IPv6 not available")
+	}
+	server.Listener = l
+	server.StartTLS()
+	return server
+}
+
+func TestAddServerIpHeaderIpv6(t *testing.T) {
+	proxy := goproxy.NewProxyHttpServer(goproxy.WithAddServerIpHeader(true))
+	s := httptest.NewServer(proxy)
+	proxyUrl, _ := url.Parse(s.URL)
+	
+	ipv6 := newIPv6TestServer(t, ConstantHanlder("bobo"))
+	defer ipv6.Close()
+
+	tr := &http.Transport{
+		OnProxyConnectResponse: func(ctx context.Context, proxyURL *url.URL, connectReq *http.Request, connectRes *http.Response) error {
+			serverIP := connectRes.Header.Get(goproxy.ServerIpHeaderKey)
+			if serverIP != "::1" {
+				t.Errorf("Expected ::1, got %s", serverIP)
+			}
+			return nil
+		},
+		Proxy:           http.ProxyURL(proxyUrl),
+		TLSClientConfig: acceptAllCerts,
+	}
+	client := &http.Client{Transport: tr}
+	if resp := string(getOrFail(ipv6.URL+"/bobo", client, t)); resp != "bobo" {
+		t.Error("Wrong response when mitm", resp, "expected bobo")
+	}
+}


### PR DESCRIPTION
Adds a configuration flag `AddServerIpHeader` which populates the response header of HTTP Connect Request with `X-Server-Ip` header containing IP for remote server being connected. 

The unit test is requires  `Transport.OnProxyConnectResponse` API which was introduced in go1.20 hence custom build tags were used. 