### PR TITLE
Add hooks to customize http connect to upstream proxy

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -2,6 +2,7 @@ package goproxy
 
 import (
 	"bufio"
+	"crypto/tls"
 	"io"
 	"log"
 	"net"
@@ -57,6 +58,16 @@ type ProxyHttpServer struct {
 	// ConnectRespHandler allows users to mutate the response to the CONNECT request before it
 	// is returned to the client.
 	ConnectRespHandler func(ctx *ProxyCtx, resp *http.Response) error
+
+	// UpstreamProxyTLSConfigHandler is called after TCP establishment but before TLS
+	// connection to an upstream HTTPS proxy.
+	// If it returns an error, the connection is closed and the error is returned to the client.
+	UpstreamProxyTLSConfigHandler func(ctx *ProxyCtx, baseConfig *tls.Config, proxyURL *url.URL) (*tls.Config, error)
+
+	// UpstreamProxyConnectReqHandler is called before sending a CONNECT request to an upstream proxy.
+	// It can modify the request that will be sent to the upstream proxy.
+	// If it returns an error, the connection is closed and the error is returned to the client.
+	UpstreamProxyConnectReqHandler func(ctx *ProxyCtx, req *http.Request) error
 
 	// HTTP and HTTPS proxy addresses
 	HttpProxyAddr  string


### PR DESCRIPTION
## Description
Add handlers to allow customization of connection to upstream proxies.

Hooks added:
1. Ability to modify TLS settings for upstream proxy (eg: to enable mTLS)
2. Ability to tweak HTTP Connect Request to upstream proxy (eg: to add context in headers)

## Testing
Verified end-to-end usage using smokescreen for both handlers.