### PR TITLE
Throw error when request writing fails for CONNECT request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 on: [push, pull_request]
 name: Test
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 jobs:
   test:
     strategy:
@@ -11,11 +9,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
     - name: Test
       run: |
         go mod verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 name: Test
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 jobs:
   test:
     strategy:

--- a/https.go
+++ b/https.go
@@ -599,7 +599,11 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 		}
 	}
 
-	connectReq.Write(c)
+	if err := connectReq.Write(c); err != nil {
+		c.Close()
+		return nil, fmt.Errorf("connectDialProxyWithContext: write CONNECT request: %w", err)
+	}
+
 	// Read response.
 	// Okay to use and discard buffered reader here, because
 	// TLS server will not speak until spoken to.

--- a/https_error_test.go
+++ b/https_error_test.go
@@ -1,0 +1,60 @@
+package goproxy
+
+import (
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testAddr string
+
+func (a testAddr) Network() string { return "tcp" }
+func (a testAddr) String() string  { return string(a) }
+
+type writeErrConn struct {
+	closed   bool
+	writeErr error
+}
+
+func (c *writeErrConn) Read(_ []byte) (int, error)       { return 0, io.EOF }
+func (c *writeErrConn) Write(_ []byte) (int, error)      { return 0, c.writeErr }
+func (c *writeErrConn) Close() error                     { c.closed = true; return nil }
+func (c *writeErrConn) LocalAddr() net.Addr              { return testAddr("local") }
+func (c *writeErrConn) RemoteAddr() net.Addr             { return testAddr("remote") }
+func (c *writeErrConn) SetDeadline(time.Time) error      { return nil }
+func (c *writeErrConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *writeErrConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestConnectDialProxyWithContextReturnsWriteError(t *testing.T) {
+	proxy := NewProxyHttpServer()
+	expectedErr := errors.New("write failed")
+	conn := &writeErrConn{writeErr: expectedErr}
+
+	proxy.ConnectDialContext = func(ctx *ProxyCtx, network, addr string) (net.Conn, error) {
+		if network != "tcp" {
+			t.Fatalf("unexpected network %q", network)
+		}
+		if addr != "proxy.example:8080" {
+			t.Fatalf("unexpected proxy addr %q", addr)
+		}
+		return conn, nil
+	}
+
+	ctx := &ProxyCtx{proxy: proxy}
+	_, err := proxy.connectDialProxyWithContext(ctx, "http://proxy.example:8080", "example.com:443")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected write error to be wrapped, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "write CONNECT request") {
+		t.Fatalf("expected wrapped write error, got %q", err)
+	}
+	if !conn.closed {
+		t.Fatal("expected upstream proxy connection to be closed")
+	}
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -780,11 +780,7 @@ func TestHttpProxyAddrsFromEnv(t *testing.T) {
 func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	// The request essentially does:
 	// Client -> FakeStripeEgressProxy -> FakeExternalProxy -> FinalDestination
-	finalDestination := httptest.NewTLSServer(HeadersHandler{})
-	defer finalDestination.Close()
-
-	finalDestinationHost := "final.destination.test"
-	finalDestinationURL := "https://" + finalDestinationHost + "/headers"
+	finalDestinationUrl := "https://httpbin.org/get"
 
 	// We'll use this counter to mark whether FakeStripeEgressProxy has been called
 	c := 0
@@ -797,15 +793,7 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	// os.Setenv("https_proxy", "http://incorrectproxy.com")
 
 	fakeExternalProxy := goproxy.NewProxyHttpServer()
-	fakeExternalProxy.Tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		if addr == finalDestinationHost+":443" {
-			addr = finalDestination.Listener.Addr().String()
-		}
-		var dialer net.Dialer
-		return dialer.DialContext(ctx, network, addr)
-	}
 	fakeExternalProxyTestStruct := httptest.NewServer(fakeExternalProxy)
-	defer fakeExternalProxyTestStruct.Close()
 	var AlwaysMitmAndPassthrough goproxy.FuncHttpsHandler = func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
 		if ctx.Req.Header["Proxy-Authorization"][0] != "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk" {
 			t.Error("Expected the Proxy-Authorization header to be present in the CONNECT request!")
@@ -825,7 +813,6 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	// We set the CONNECT response handler function to increment our counter such that we can tell
 	// if our FakeStripeEgressProxy was actually called
 	fakeStripeEgressProxyTestStruct := httptest.NewServer(fakeStripeEgressProxy)
-	defer fakeStripeEgressProxyTestStruct.Close()
 
 	egressProxyUrl, _ := url.Parse(fakeStripeEgressProxyTestStruct.URL)
 	externalProxyUrl, _ := url.Parse(fakeExternalProxyTestStruct.URL)
@@ -850,7 +837,7 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	}
 	client := &http.Client{Transport: tr}
 
-	req, err := http.NewRequest("GET", finalDestinationURL, nil)
+	req, err := http.NewRequest("GET", finalDestinationUrl, nil)
 	if err != nil {
 		t.Fatal("Unable to construct request!")
 	}
@@ -861,7 +848,6 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unable to make the request!")
 	}
-	defer res.Body.Close()
 
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -870,7 +856,7 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	resBody := string(bodyBytes)
 
 	// Making sure we received the response we expected from the final destination
-	if !strings.Contains(resBody, "X-Test-Header-Key: Test-Header-Value;") {
+	if !strings.Contains(resBody, "\"X-Test-Header-Key\": \"Test-Header-Value\"") {
 		t.Error("Expected the passed request headers to be present in the response body!")
 	}
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -780,7 +780,11 @@ func TestHttpProxyAddrsFromEnv(t *testing.T) {
 func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	// The request essentially does:
 	// Client -> FakeStripeEgressProxy -> FakeExternalProxy -> FinalDestination
-	finalDestinationUrl := "https://httpbin.org/get"
+	finalDestination := httptest.NewTLSServer(HeadersHandler{})
+	defer finalDestination.Close()
+
+	finalDestinationHost := "final.destination.test"
+	finalDestinationURL := "https://" + finalDestinationHost + "/headers"
 
 	// We'll use this counter to mark whether FakeStripeEgressProxy has been called
 	c := 0
@@ -793,7 +797,15 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	// os.Setenv("https_proxy", "http://incorrectproxy.com")
 
 	fakeExternalProxy := goproxy.NewProxyHttpServer()
+	fakeExternalProxy.Tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if addr == finalDestinationHost+":443" {
+			addr = finalDestination.Listener.Addr().String()
+		}
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, network, addr)
+	}
 	fakeExternalProxyTestStruct := httptest.NewServer(fakeExternalProxy)
+	defer fakeExternalProxyTestStruct.Close()
 	var AlwaysMitmAndPassthrough goproxy.FuncHttpsHandler = func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
 		if ctx.Req.Header["Proxy-Authorization"][0] != "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk" {
 			t.Error("Expected the Proxy-Authorization header to be present in the CONNECT request!")
@@ -813,6 +825,7 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	// We set the CONNECT response handler function to increment our counter such that we can tell
 	// if our FakeStripeEgressProxy was actually called
 	fakeStripeEgressProxyTestStruct := httptest.NewServer(fakeStripeEgressProxy)
+	defer fakeStripeEgressProxyTestStruct.Close()
 
 	egressProxyUrl, _ := url.Parse(fakeStripeEgressProxyTestStruct.URL)
 	externalProxyUrl, _ := url.Parse(fakeExternalProxyTestStruct.URL)
@@ -837,7 +850,7 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	}
 	client := &http.Client{Transport: tr}
 
-	req, err := http.NewRequest("GET", finalDestinationUrl, nil)
+	req, err := http.NewRequest("GET", finalDestinationURL, nil)
 	if err != nil {
 		t.Fatal("Unable to construct request!")
 	}
@@ -848,6 +861,7 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unable to make the request!")
 	}
+	defer res.Body.Close()
 
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -856,7 +870,7 @@ func TestOverrideHttpsProxyAddrsFromEnvWithRequest(t *testing.T) {
 	resBody := string(bodyBytes)
 
 	// Making sure we received the response we expected from the final destination
-	if !strings.Contains(resBody, "\"X-Test-Header-Key\": \"Test-Header-Value\"") {
+	if !strings.Contains(resBody, "X-Test-Header-Key: Test-Header-Value;") {
 		t.Error("Expected the passed request headers to be present in the response body!")
 	}
 


### PR DESCRIPTION
If there was an error writing request, it wasn't handled. This PR handles that error and also implements test cases for it. 

Also updates to use latest github actions as per https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ 