### PR TITLE
Fix MITM certificate randomness

### DIFF
--- a/counterecryptor.go
+++ b/counterecryptor.go
@@ -25,13 +25,14 @@ func NewCounterEncryptorRandFromKey(key interface{}, seed []byte) (r CounterEncr
 		err = errors.New("only RSA keys supported")
 		return
 	}
-	h := sha256.New()
-	if r.cipher, err = aes.NewCipher(h.Sum(keyBytes)[:aes.BlockSize]); err != nil {
+	keyDigest := sha256.Sum256(keyBytes)
+	if r.cipher, err = aes.NewCipher(keyDigest[:aes.BlockSize]); err != nil {
 		return
 	}
 	r.counter = make([]byte, r.cipher.BlockSize())
 	if seed != nil {
-		copy(r.counter, h.Sum(seed)[:r.cipher.BlockSize()])
+		seedDigest := sha256.Sum256(seed)
+		copy(r.counter, seedDigest[:r.cipher.BlockSize()])
 	}
 	r.rand = make([]byte, r.cipher.BlockSize())
 	r.ix = len(r.rand)

--- a/counterecryptor_test.go
+++ b/counterecryptor_test.go
@@ -2,7 +2,10 @@ package goproxy_test
 
 import (
 	"bytes"
+	"crypto/aes"
 	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
 	"encoding/binary"
 	"io"
 	"math"
@@ -12,20 +15,47 @@ import (
 	"github.com/stripe/goproxy"
 )
 
-type RandSeedReader struct {
-	r rand.Rand
+func testRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	k, ok := goproxy.GoproxyCa.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatalf("expected RSA private key, got %T", goproxy.GoproxyCa.PrivateKey)
+	}
+	return k
 }
 
-func (r *RandSeedReader) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = byte(r.r.Int() & 0xFF)
+func TestCounterEncUsesSHA256KeyAndSeed(t *testing.T) {
+	k := testRSAKey(t)
+	seed := []byte("the quick brown fox run over the lazy dog")
+	c, err := goproxy.NewCounterEncryptorRandFromKey(k, seed)
+	fatalOnErr(err, "NewCounterEncryptorRandFromKey", t)
+
+	got := make([]byte, aes.BlockSize)
+	_, err = io.ReadFull(&c, got)
+	fatalOnErr(err, "CounterEncryptorRand.Read", t)
+
+	keyBytes := x509.MarshalPKCS1PrivateKey(k)
+	keyDigest := sha256.Sum256(keyBytes)
+	seedDigest := sha256.Sum256(seed)
+	block, err := aes.NewCipher(keyDigest[:aes.BlockSize])
+	fatalOnErr(err, "aes.NewCipher", t)
+	expected := make([]byte, aes.BlockSize)
+	block.Encrypt(expected, seedDigest[:aes.BlockSize])
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("CounterEncryptorRand did not use SHA-256-derived key and seed")
 	}
-	return len(b), nil
+
+	legacyBlock, err := aes.NewCipher(keyBytes[:aes.BlockSize])
+	fatalOnErr(err, "aes.NewCipher legacy", t)
+	legacy := make([]byte, aes.BlockSize)
+	legacyBlock.Encrypt(legacy, seed[:aes.BlockSize])
+	if bytes.Equal(got, legacy) {
+		t.Fatalf("CounterEncryptorRand used raw key and seed prefixes")
+	}
 }
 
 func TestCounterEncDifferentConsecutive(t *testing.T) {
-	k, err := rsa.GenerateKey(&RandSeedReader{*rand.New(rand.NewSource(0xFF43109))}, 128)
-	fatalOnErr(err, "rsa.GenerateKey", t)
+	k := testRSAKey(t)
 	c, err := goproxy.NewCounterEncryptorRandFromKey(k, []byte("the quick brown fox run over the lazy dog"))
 	fatalOnErr(err, "NewCounterEncryptorRandFromKey", t)
 	for i := 0; i < 100*1000; i++ {
@@ -39,8 +69,7 @@ func TestCounterEncDifferentConsecutive(t *testing.T) {
 }
 
 func TestCounterEncIdenticalStreams(t *testing.T) {
-	k, err := rsa.GenerateKey(&RandSeedReader{*rand.New(rand.NewSource(0xFF43109))}, 128)
-	fatalOnErr(err, "rsa.GenerateKey", t)
+	k := testRSAKey(t)
 	c1, err := goproxy.NewCounterEncryptorRandFromKey(k, []byte("the quick brown fox run over the lazy dog"))
 	fatalOnErr(err, "NewCounterEncryptorRandFromKey", t)
 	c2, err := goproxy.NewCounterEncryptorRandFromKey(k, []byte("the quick brown fox run over the lazy dog"))
@@ -76,8 +105,7 @@ func stddev(data []int) float64 {
 }
 
 func TestCounterEncStreamHistogram(t *testing.T) {
-	k, err := rsa.GenerateKey(&RandSeedReader{*rand.New(rand.NewSource(0xFF43109))}, 128)
-	fatalOnErr(err, "rsa.GenerateKey", t)
+	k := testRSAKey(t)
 	c, err := goproxy.NewCounterEncryptorRandFromKey(k, []byte("the quick brown fox run over the lazy dog"))
 	fatalOnErr(err, "NewCounterEncryptorRandFromKey", t)
 	nout := 100 * 1000

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/stripe/goproxy
 go 1.13
 
 require (
+	github.com/hashicorp/golang-lru v1.0.2
 	github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31 h1:DE4LcMKyqAVa6a0CGmVxANbnVb7stzMmPkQiieyNmfQ=
 github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/https.go
+++ b/https.go
@@ -3,7 +3,6 @@ package goproxy
 import (
 	"bufio"
 	"bytes"
-	"container/list"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
@@ -22,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru"
 	"golang.org/x/net/http/httpproxy"
 )
 
@@ -550,16 +550,13 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 }
 
 type mitmCertCache struct {
-	mu         sync.Mutex
-	maxEntries int
-	ttl        time.Duration
-	now        func() time.Time
-	entries    map[string]*list.Element
-	lru        *list.List
+	mu      sync.Mutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries *lru.Cache
 }
 
 type mitmCertCacheEntry struct {
-	host      string
 	cert      tls.Certificate
 	expiresAt time.Time
 }
@@ -568,66 +565,52 @@ func newMITMCertCache(maxEntries int, ttl time.Duration) *mitmCertCache {
 	if maxEntries <= 0 || ttl <= 0 {
 		return nil
 	}
+	entries, err := lru.New(maxEntries)
+	if err != nil {
+		return nil
+	}
 	return &mitmCertCache{
-		maxEntries: maxEntries,
-		ttl:        ttl,
-		now:        time.Now,
-		entries:    make(map[string]*list.Element),
-		lru:        list.New(),
+		ttl:     ttl,
+		now:     time.Now,
+		entries: entries,
 	}
 }
 
 func (c *mitmCertCache) get(host string) (tls.Certificate, bool) {
-	now := c.now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	elem, ok := c.entries[host]
+	value, ok := c.entries.Get(host)
 	if !ok {
 		return tls.Certificate{}, false
 	}
-	entry := elem.Value.(*mitmCertCacheEntry)
-	if !entry.expiresAt.After(now) {
-		c.removeElement(elem)
+	entry := value.(mitmCertCacheEntry)
+	if !entry.expiresAt.After(c.now()) {
+		c.entries.Remove(host)
 		return tls.Certificate{}, false
 	}
-	c.lru.MoveToFront(elem)
 	return entry.cert, true
 }
 
 func (c *mitmCertCache) store(host string, cert tls.Certificate) tls.Certificate {
-	now := c.now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if elem, ok := c.entries[host]; ok {
-		entry := elem.Value.(*mitmCertCacheEntry)
+	now := c.now()
+	if value, ok := c.entries.Get(host); ok {
+		entry := value.(mitmCertCacheEntry)
 		if entry.expiresAt.After(now) {
-			c.lru.MoveToFront(elem)
 			return entry.cert
 		}
-		c.removeElement(elem)
+		c.entries.Remove(host)
 	}
 
-	entry := &mitmCertCacheEntry{
-		host:      host,
+	entry := mitmCertCacheEntry{
 		cert:      cert,
 		expiresAt: now.Add(c.ttl),
 	}
-	c.entries[host] = c.lru.PushFront(entry)
-	for c.lru.Len() > c.maxEntries {
-		c.removeElement(c.lru.Back())
-	}
+	c.entries.Add(host, entry)
 	return cert
-}
-
-func (c *mitmCertCache) removeElement(elem *list.Element) {
-	if elem == nil {
-		return
-	}
-	entry := elem.Value.(*mitmCertCacheEntry)
-	delete(c.entries, entry.host)
-	c.lru.Remove(elem)
 }
 
 func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {

--- a/https.go
+++ b/https.go
@@ -600,6 +600,8 @@ func (c *mitmCertCache) store(host string, cert tls.Certificate) tls.Certificate
 	if value, ok := c.entries.Get(host); ok {
 		entry := value.(mitmCertCacheEntry)
 		if entry.expiresAt.After(now) {
+			entry.expiresAt = now.Add(c.ttl)
+			c.entries.Add(host, entry)
 			return entry.cert
 		}
 		c.entries.Remove(host)

--- a/https.go
+++ b/https.go
@@ -3,6 +3,7 @@ package goproxy
 import (
 	"bufio"
 	"bytes"
+	"container/list"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
@@ -17,9 +18,20 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"golang.org/x/net/http/httpproxy"
+)
+
+const (
+	// DefaultMITMCertCacheMaxEntries limits the number of generated MITM leaf
+	// certificates cached by TLSConfigFromCA.
+	DefaultMITMCertCacheMaxEntries = 4096
+	// DefaultMITMCertCacheTTL controls how long TLSConfigFromCA reuses a generated
+	// MITM leaf certificate for a host.
+	DefaultMITMCertCacheTTL = time.Hour
 )
 
 type ConnectActionLiteral int
@@ -537,14 +549,115 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 	return nil
 }
 
+type mitmCertCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	ttl        time.Duration
+	now        func() time.Time
+	entries    map[string]*list.Element
+	lru        *list.List
+}
+
+type mitmCertCacheEntry struct {
+	host      string
+	cert      tls.Certificate
+	expiresAt time.Time
+}
+
+func newMITMCertCache(maxEntries int, ttl time.Duration) *mitmCertCache {
+	if maxEntries <= 0 || ttl <= 0 {
+		return nil
+	}
+	return &mitmCertCache{
+		maxEntries: maxEntries,
+		ttl:        ttl,
+		now:        time.Now,
+		entries:    make(map[string]*list.Element),
+		lru:        list.New(),
+	}
+}
+
+func (c *mitmCertCache) get(host string) (tls.Certificate, bool) {
+	now := c.now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.entries[host]
+	if !ok {
+		return tls.Certificate{}, false
+	}
+	entry := elem.Value.(*mitmCertCacheEntry)
+	if !entry.expiresAt.After(now) {
+		c.removeElement(elem)
+		return tls.Certificate{}, false
+	}
+	c.lru.MoveToFront(elem)
+	return entry.cert, true
+}
+
+func (c *mitmCertCache) store(host string, cert tls.Certificate) tls.Certificate {
+	now := c.now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.entries[host]; ok {
+		entry := elem.Value.(*mitmCertCacheEntry)
+		if entry.expiresAt.After(now) {
+			c.lru.MoveToFront(elem)
+			return entry.cert
+		}
+		c.removeElement(elem)
+	}
+
+	entry := &mitmCertCacheEntry{
+		host:      host,
+		cert:      cert,
+		expiresAt: now.Add(c.ttl),
+	}
+	c.entries[host] = c.lru.PushFront(entry)
+	for c.lru.Len() > c.maxEntries {
+		c.removeElement(c.lru.Back())
+	}
+	return cert
+}
+
+func (c *mitmCertCache) removeElement(elem *list.Element) {
+	if elem == nil {
+		return
+	}
+	entry := elem.Value.(*mitmCertCacheEntry)
+	delete(c.entries, entry.host)
+	c.lru.Remove(elem)
+}
+
 func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
+	return TLSConfigFromCAWithCache(ca, DefaultMITMCertCacheMaxEntries, DefaultMITMCertCacheTTL)
+}
+
+// TLSConfigFromCAWithCache returns a TLS config generator that signs MITM leaf
+// certificates with ca and reuses generated certificates for the same host while
+// they remain in the bounded TTL cache. Set cacheMaxEntries or cacheTTL to zero
+// to disable caching.
+func TLSConfigFromCAWithCache(ca *tls.Certificate, cacheMaxEntries int, cacheTTL time.Duration) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
+	certCache := newMITMCertCache(cacheMaxEntries, cacheTTL)
 	return func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 		config := defaultTLSConfig.Clone()
-		ctx.Logf("signing for %s", stripPort(host))
-		cert, err := signHost(*ca, []string{stripPort(host)})
+		strippedHost := stripPort(host)
+		if certCache != nil {
+			if cert, ok := certCache.get(strippedHost); ok {
+				config.Certificates = append(config.Certificates, cert)
+				return config, nil
+			}
+		}
+
+		ctx.Logf("signing for %s", strippedHost)
+		cert, err := signHost(*ca, []string{strippedHost})
 		if err != nil {
 			ctx.Warnf("Cannot sign host certificate with provided CA: %s", err)
 			return nil, err
+		}
+		if certCache != nil {
+			cert = certCache.store(strippedHost, cert)
 		}
 		config.Certificates = append(config.Certificates, cert)
 		return config, nil

--- a/signer.go
+++ b/signer.go
@@ -1,36 +1,15 @@
 package goproxy
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
 	"net"
-	"runtime"
-	"sort"
 	"time"
 )
-
-func hashSorted(lst []string) []byte {
-	c := make([]string, len(lst))
-	copy(c, lst)
-	sort.Strings(c)
-	h := sha1.New()
-	for _, s := range c {
-		h.Write([]byte(s + ","))
-	}
-	return h.Sum(nil)
-}
-
-func hashSortedBigInt(lst []string) *big.Int {
-	rv := new(big.Int)
-	rv.SetBytes(hashSorted(lst))
-	return rv
-}
-
-var goproxySignerVersion = ":goroxy1"
 
 func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err error) {
 	var x509ca *x509.Certificate
@@ -44,11 +23,13 @@ func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err err
 	if err != nil {
 		panic(err)
 	}
-	hash := hashSorted(append(hosts, goproxySignerVersion, ":"+runtime.Version()))
-	serial := new(big.Int)
-	serial.SetBytes(hash)
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return
+	}
+	serial.Add(serial, big.NewInt(1))
 	template := x509.Certificate{
-		// TODO(elazar): instead of this ugly hack, just encode the certificate and hash the binary form.
 		SerialNumber: serial,
 		Issuer:       x509ca.Subject,
 		Subject: pkix.Name{
@@ -69,16 +50,12 @@ func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err err
 			template.Subject.CommonName = h
 		}
 	}
-	var csprng CounterEncryptorRand
-	if csprng, err = NewCounterEncryptorRandFromKey(ca.PrivateKey, hash); err != nil {
-		return
-	}
 	var certpriv *rsa.PrivateKey
-	if certpriv, err = rsa.GenerateKey(&csprng, 2048); err != nil {
+	if certpriv, err = rsa.GenerateKey(rand.Reader, 2048); err != nil {
 		return
 	}
 	var derBytes []byte
-	if derBytes, err = x509.CreateCertificate(&csprng, &template, x509ca, &certpriv.PublicKey, ca.PrivateKey); err != nil {
+	if derBytes, err = x509.CreateCertificate(rand.Reader, &template, x509ca, &certpriv.PublicKey, ca.PrivateKey); err != nil {
 		return
 	}
 	return tls.Certificate{

--- a/signer_test.go
+++ b/signer_test.go
@@ -67,6 +67,21 @@ func TestMITMCertCacheReturnsStoredCertificate(t *testing.T) {
 	}
 }
 
+func TestMITMCertCacheDuplicateStoreRefreshesTTL(t *testing.T) {
+	now := time.Unix(100, 0)
+	cache := newMITMCertCache(2, time.Hour)
+	cache.now = func() time.Time { return now }
+
+	cache.store("example.com", testTLSCertificate(1))
+	now = now.Add(30 * time.Minute)
+	cache.store("example.com", testTLSCertificate(2))
+
+	now = now.Add(31 * time.Minute)
+	if got, ok := cache.get("example.com"); !ok || got.Certificate[0][0] != 1 {
+		t.Fatalf("expected cached certificate 1 after refreshed TTL, got %v, ok=%v", got.Certificate, ok)
+	}
+}
+
 func TestMITMCertCacheEvictsLeastRecentlyUsedCertificate(t *testing.T) {
 	cache := newMITMCertCache(2, time.Hour)
 	cache.store("first.example", testTLSCertificate(1))

--- a/signer_test.go
+++ b/signer_test.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
@@ -25,6 +26,19 @@ func (h ConstantHanlder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(h))
 }
 
+func rsaPrivateKeyFromCert(t *testing.T, cert tls.Certificate) *rsa.PrivateKey {
+	t.Helper()
+	key, ok := cert.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatalf("expected RSA private key, got %T", cert.PrivateKey)
+	}
+	return key
+}
+
+func testTLSCertificate(id byte) tls.Certificate {
+	return tls.Certificate{Certificate: [][]byte{{id}}}
+}
+
 func getBrowser(args []string) string {
 	for i, arg := range args {
 		if arg == "-browser" && i+1 < len(arg) {
@@ -35,6 +49,120 @@ func getBrowser(args []string) string {
 		}
 	}
 	return ""
+}
+
+func TestMITMCertCacheReturnsStoredCertificate(t *testing.T) {
+	cache := newMITMCertCache(2, time.Hour)
+	cert1 := testTLSCertificate(1)
+	cert2 := testTLSCertificate(2)
+
+	if got := cache.store("example.com", cert1); got.Certificate[0][0] != 1 {
+		t.Fatalf("expected stored certificate 1, got %d", got.Certificate[0][0])
+	}
+	if got := cache.store("example.com", cert2); got.Certificate[0][0] != 1 {
+		t.Fatalf("expected existing certificate 1 on duplicate store, got %d", got.Certificate[0][0])
+	}
+	if got, ok := cache.get("example.com"); !ok || got.Certificate[0][0] != 1 {
+		t.Fatalf("expected cached certificate 1, got %v, ok=%v", got.Certificate, ok)
+	}
+}
+
+func TestMITMCertCacheEvictsLeastRecentlyUsedCertificate(t *testing.T) {
+	cache := newMITMCertCache(2, time.Hour)
+	cache.store("first.example", testTLSCertificate(1))
+	cache.store("second.example", testTLSCertificate(2))
+	if _, ok := cache.get("first.example"); !ok {
+		t.Fatal("expected first.example to be cached")
+	}
+	cache.store("third.example", testTLSCertificate(3))
+
+	if _, ok := cache.get("second.example"); ok {
+		t.Fatal("expected second.example to be evicted")
+	}
+	if _, ok := cache.get("first.example"); !ok {
+		t.Fatal("expected first.example to remain cached")
+	}
+	if _, ok := cache.get("third.example"); !ok {
+		t.Fatal("expected third.example to be cached")
+	}
+}
+
+func TestMITMCertCacheExpiresCertificates(t *testing.T) {
+	now := time.Unix(100, 0)
+	cache := newMITMCertCache(2, time.Minute)
+	cache.now = func() time.Time { return now }
+
+	cache.store("example.com", testTLSCertificate(1))
+	now = now.Add(time.Minute)
+	if _, ok := cache.get("example.com"); ok {
+		t.Fatal("expected certificate to expire at TTL boundary")
+	}
+	cache.store("example.com", testTLSCertificate(2))
+	got, ok := cache.get("example.com")
+	if !ok {
+		t.Fatal("expected replacement certificate to be cached")
+	}
+	if got.Certificate[0][0] != 2 {
+		t.Fatalf("expected replacement certificate 2, got %d", got.Certificate[0][0])
+	}
+}
+
+func TestSignHostGeneratesRandomLeafPrivateKey(t *testing.T) {
+	cert1, err := signHost(GoproxyCa, []string{"example.com"})
+	orFatal("singHost", err, t)
+	cert2, err := signHost(GoproxyCa, []string{"example.com"})
+	orFatal("singHost", err, t)
+	leaf1, err := x509.ParseCertificate(cert1.Certificate[0])
+	orFatal("ParseCertificate", err, t)
+	leaf2, err := x509.ParseCertificate(cert2.Certificate[0])
+	orFatal("ParseCertificate", err, t)
+
+	key1 := rsaPrivateKeyFromCert(t, cert1)
+	key2 := rsaPrivateKeyFromCert(t, cert2)
+	if key1.N.Cmp(key2.N) == 0 {
+		t.Fatal("signHost generated identical RSA private keys for repeated host")
+	}
+	if leaf1.SerialNumber.Cmp(leaf2.SerialNumber) == 0 {
+		t.Fatal("signHost generated identical serial numbers for repeated host")
+	}
+}
+
+func TestTLSConfigFromCACachesHostCertificates(t *testing.T) {
+	tlsConfig := TLSConfigFromCA(&GoproxyCa)
+	ctx := &ProxyCtx{proxy: NewProxyHttpServer()}
+
+	config1, err := tlsConfig("example.com:443", ctx)
+	orFatal("TLSConfigFromCA", err, t)
+	config2, err := tlsConfig("example.com:443", ctx)
+	orFatal("TLSConfigFromCA", err, t)
+	if len(config1.Certificates) != 1 {
+		t.Fatalf("expected one certificate in first TLS config, got %d", len(config1.Certificates))
+	}
+	if len(config2.Certificates) != 1 {
+		t.Fatalf("expected one certificate in second TLS config, got %d", len(config2.Certificates))
+	}
+
+	key1 := rsaPrivateKeyFromCert(t, config1.Certificates[0])
+	key2 := rsaPrivateKeyFromCert(t, config2.Certificates[0])
+	if key1 != key2 {
+		t.Fatal("TLSConfigFromCA did not reuse the cached host certificate")
+	}
+}
+
+func TestTLSConfigFromCACacheCanBeDisabled(t *testing.T) {
+	tlsConfig := TLSConfigFromCAWithCache(&GoproxyCa, 0, time.Hour)
+	ctx := &ProxyCtx{proxy: NewProxyHttpServer()}
+
+	config1, err := tlsConfig("example.com:443", ctx)
+	orFatal("TLSConfigFromCAWithCache", err, t)
+	config2, err := tlsConfig("example.com:443", ctx)
+	orFatal("TLSConfigFromCAWithCache", err, t)
+
+	key1 := rsaPrivateKeyFromCert(t, config1.Certificates[0])
+	key2 := rsaPrivateKeyFromCert(t, config2.Certificates[0])
+	if key1.N.Cmp(key2.N) == 0 {
+		t.Fatal("TLSConfigFromCAWithCache reused a certificate when caching was disabled")
+	}
 }
 
 func TestSingerTls(t *testing.T) {

--- a/vendor/github.com/hashicorp/golang-lru/.gitignore
+++ b/vendor/github.com/hashicorp/golang-lru/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/vendor/github.com/hashicorp/golang-lru/.golangci.yml
+++ b/vendor/github.com/hashicorp/golang-lru/.golangci.yml
@@ -1,0 +1,30 @@
+linters:
+  enable:
+    - megacheck
+    - revive
+    - govet
+    - unconvert
+    - megacheck
+    - gas
+    - gocyclo
+    - dupl
+    - misspell
+    - unparam
+    - unused
+    - typecheck
+    - ineffassign
+    - stylecheck
+    - exportloopref
+    - gocritic
+    - nakedret
+    - gosimple
+    - prealloc
+  fast: false
+  disable-all: true
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+  exclude-use-default: false

--- a/vendor/github.com/hashicorp/golang-lru/2q.go
+++ b/vendor/github.com/hashicorp/golang-lru/2q.go
@@ -1,0 +1,222 @@
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+const (
+	// Default2QRecentRatio is the ratio of the 2Q cache dedicated
+	// to recently added entries that have only been accessed once.
+	Default2QRecentRatio = 0.25
+
+	// Default2QGhostEntries is the default ratio of ghost
+	// entries kept to track entries recently evicted
+	Default2QGhostEntries = 0.50
+)
+
+// TwoQueueCache is a thread-safe fixed size 2Q cache.
+// 2Q is an enhancement over the standard LRU cache
+// in that it tracks both frequently and recently used
+// entries separately. This avoids a burst in access to new
+// entries from evicting frequently used entries. It adds some
+// additional tracking overhead to the standard LRU cache, and is
+// computationally about 2x the cost, and adds some metadata over
+// head. The ARCCache is similar, but does not require setting any
+// parameters.
+type TwoQueueCache struct {
+	size       int
+	recentSize int
+
+	recent      simplelru.LRUCache
+	frequent    simplelru.LRUCache
+	recentEvict simplelru.LRUCache
+	lock        sync.RWMutex
+}
+
+// New2Q creates a new TwoQueueCache using the default
+// values for the parameters.
+func New2Q(size int) (*TwoQueueCache, error) {
+	return New2QParams(size, Default2QRecentRatio, Default2QGhostEntries)
+}
+
+// New2QParams creates a new TwoQueueCache using the provided
+// parameter values.
+func New2QParams(size int, recentRatio, ghostRatio float64) (*TwoQueueCache, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid size")
+	}
+	if recentRatio < 0.0 || recentRatio > 1.0 {
+		return nil, fmt.Errorf("invalid recent ratio")
+	}
+	if ghostRatio < 0.0 || ghostRatio > 1.0 {
+		return nil, fmt.Errorf("invalid ghost ratio")
+	}
+
+	// Determine the sub-sizes
+	recentSize := int(float64(size) * recentRatio)
+	evictSize := int(float64(size) * ghostRatio)
+
+	// Allocate the LRUs
+	recent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	frequent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	recentEvict, err := simplelru.NewLRU(evictSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the cache
+	c := &TwoQueueCache{
+		size:        size,
+		recentSize:  recentSize,
+		recent:      recent,
+		frequent:    frequent,
+		recentEvict: recentEvict,
+	}
+	return c, nil
+}
+
+// Get looks up a key's value from the cache.
+func (c *TwoQueueCache) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if this is a frequent value
+	if val, ok := c.frequent.Get(key); ok {
+		return val, ok
+	}
+
+	// If the value is contained in recent, then we
+	// promote it to frequent
+	if val, ok := c.recent.Peek(key); ok {
+		c.recent.Remove(key)
+		c.frequent.Add(key, val)
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+// Add adds a value to the cache.
+func (c *TwoQueueCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is frequently used already,
+	// and just update the value
+	if c.frequent.Contains(key) {
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Check if the value is recently used, and promote
+	// the value into the frequent list
+	if c.recent.Contains(key) {
+		c.recent.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// If the value was recently evicted, add it to the
+	// frequently used list
+	if c.recentEvict.Contains(key) {
+		c.ensureSpace(true)
+		c.recentEvict.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Add to the recently seen list
+	c.ensureSpace(false)
+	c.recent.Add(key, value)
+}
+
+// ensureSpace is used to ensure we have space in the cache
+func (c *TwoQueueCache) ensureSpace(recentEvict bool) {
+	// If we have space, nothing to do
+	recentLen := c.recent.Len()
+	freqLen := c.frequent.Len()
+	if recentLen+freqLen < c.size {
+		return
+	}
+
+	// If the recent buffer is larger than
+	// the target, evict from there
+	if recentLen > 0 && (recentLen > c.recentSize || (recentLen == c.recentSize && !recentEvict)) {
+		k, _, _ := c.recent.RemoveOldest()
+		c.recentEvict.Add(k, nil)
+		return
+	}
+
+	// Remove from the frequent list otherwise
+	c.frequent.RemoveOldest()
+}
+
+// Len returns the number of items in the cache.
+func (c *TwoQueueCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.recent.Len() + c.frequent.Len()
+}
+
+// Keys returns a slice of the keys in the cache.
+// The frequently used keys are first in the returned slice.
+func (c *TwoQueueCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.frequent.Keys()
+	k2 := c.recent.Keys()
+	return append(k1, k2...)
+}
+
+// Remove removes the provided key from the cache.
+func (c *TwoQueueCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.frequent.Remove(key) {
+		return
+	}
+	if c.recent.Remove(key) {
+		return
+	}
+	if c.recentEvict.Remove(key) {
+		return
+	}
+}
+
+// Purge is used to completely clear the cache.
+func (c *TwoQueueCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.recent.Purge()
+	c.frequent.Purge()
+	c.recentEvict.Purge()
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (c *TwoQueueCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.frequent.Contains(key) || c.recent.Contains(key)
+}
+
+// Peek is used to inspect the cache value of a key
+// without updating recency or frequency.
+func (c *TwoQueueCache) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.frequent.Peek(key); ok {
+		return val, ok
+	}
+	return c.recent.Peek(key)
+}

--- a/vendor/github.com/hashicorp/golang-lru/LICENSE
+++ b/vendor/github.com/hashicorp/golang-lru/LICENSE
@@ -1,0 +1,364 @@
+Copyright (c) 2014 HashiCorp, Inc.
+
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/hashicorp/golang-lru/README.md
+++ b/vendor/github.com/hashicorp/golang-lru/README.md
@@ -1,0 +1,7 @@
+golang-lru
+==========
+
+Please upgrade to github.com/hashicorp/golang-lru/v2 for all new code as v1 will
+not be updated anymore. The v2 version supports generics and is faster; old code
+can specify a specific tag, e.g. github.com/hashicorp/golang-lru/v1.0.2 for
+backwards compatibility.

--- a/vendor/github.com/hashicorp/golang-lru/arc.go
+++ b/vendor/github.com/hashicorp/golang-lru/arc.go
@@ -1,0 +1,256 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// ARCCache is a thread-safe fixed size Adaptive Replacement Cache (ARC).
+// ARC is an enhancement over the standard LRU cache in that tracks both
+// frequency and recency of use. This avoids a burst in access to new
+// entries from evicting the frequently used older entries. It adds some
+// additional tracking overhead to a standard LRU cache, computationally
+// it is roughly 2x the cost, and the extra memory overhead is linear
+// with the size of the cache. ARC has been patented by IBM, but is
+// similar to the TwoQueueCache (2Q) which requires setting parameters.
+type ARCCache struct {
+	size int // Size is the total capacity of the cache
+	p    int // P is the dynamic preference towards T1 or T2
+
+	t1 simplelru.LRUCache // T1 is the LRU for recently accessed items
+	b1 simplelru.LRUCache // B1 is the LRU for evictions from t1
+
+	t2 simplelru.LRUCache // T2 is the LRU for frequently accessed items
+	b2 simplelru.LRUCache // B2 is the LRU for evictions from t2
+
+	lock sync.RWMutex
+}
+
+// NewARC creates an ARC of the given size
+func NewARC(size int) (*ARCCache, error) {
+	// Create the sub LRUs
+	b1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the ARC
+	c := &ARCCache{
+		size: size,
+		p:    0,
+		t1:   t1,
+		b1:   b1,
+		t2:   t2,
+		b2:   b2,
+	}
+	return c, nil
+}
+
+// Get looks up a key's value from the cache.
+func (c *ARCCache) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// If the value is contained in T1 (recent), then
+	// promote it to T2 (frequent)
+	if val, ok := c.t1.Peek(key); ok {
+		c.t1.Remove(key)
+		c.t2.Add(key, val)
+		return val, ok
+	}
+
+	// Check if the value is contained in T2 (frequent)
+	if val, ok := c.t2.Get(key); ok {
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+// Add adds a value to the cache.
+func (c *ARCCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is contained in T1 (recent), and potentially
+	// promote it to frequent T2
+	if c.t1.Contains(key) {
+		c.t1.Remove(key)
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if the value is already in T2 (frequent) and update it
+	if c.t2.Contains(key) {
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// recently used list
+	if c.b1.Contains(key) {
+		// T1 set is too small, increase P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b2Len > b1Len {
+			delta = b2Len / b1Len
+		}
+		if c.p+delta >= c.size {
+			c.p = c.size
+		} else {
+			c.p += delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(false)
+		}
+
+		// Remove from B1
+		c.b1.Remove(key)
+
+		// Add the key to the frequently used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// frequently used list
+	if c.b2.Contains(key) {
+		// T2 set is too small, decrease P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b1Len > b2Len {
+			delta = b1Len / b2Len
+		}
+		if delta >= c.p {
+			c.p = 0
+		} else {
+			c.p -= delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(true)
+		}
+
+		// Remove from B2
+		c.b2.Remove(key)
+
+		// Add the key to the frequently used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Potentially need to make room in the cache
+	if c.t1.Len()+c.t2.Len() >= c.size {
+		c.replace(false)
+	}
+
+	// Keep the size of the ghost buffers trim
+	if c.b1.Len() > c.size-c.p {
+		c.b1.RemoveOldest()
+	}
+	if c.b2.Len() > c.p {
+		c.b2.RemoveOldest()
+	}
+
+	// Add to the recently seen list
+	c.t1.Add(key, value)
+}
+
+// replace is used to adaptively evict from either T1 or T2
+// based on the current learned value of P
+func (c *ARCCache) replace(b2ContainsKey bool) {
+	t1Len := c.t1.Len()
+	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
+		k, _, ok := c.t1.RemoveOldest()
+		if ok {
+			c.b1.Add(k, nil)
+		}
+	} else {
+		k, _, ok := c.t2.RemoveOldest()
+		if ok {
+			c.b2.Add(k, nil)
+		}
+	}
+}
+
+// Len returns the number of cached entries
+func (c *ARCCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Len() + c.t2.Len()
+}
+
+// Keys returns all the cached keys
+func (c *ARCCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.t1.Keys()
+	k2 := c.t2.Keys()
+	return append(k1, k2...)
+}
+
+// Remove is used to purge a key from the cache
+func (c *ARCCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.t1.Remove(key) {
+		return
+	}
+	if c.t2.Remove(key) {
+		return
+	}
+	if c.b1.Remove(key) {
+		return
+	}
+	if c.b2.Remove(key) {
+		return
+	}
+}
+
+// Purge is used to clear the cache
+func (c *ARCCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.t1.Purge()
+	c.t2.Purge()
+	c.b1.Purge()
+	c.b2.Purge()
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (c *ARCCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Contains(key) || c.t2.Contains(key)
+}
+
+// Peek is used to inspect the cache value of a key
+// without updating recency or frequency.
+func (c *ARCCache) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.t1.Peek(key); ok {
+		return val, ok
+	}
+	return c.t2.Peek(key)
+}

--- a/vendor/github.com/hashicorp/golang-lru/doc.go
+++ b/vendor/github.com/hashicorp/golang-lru/doc.go
@@ -1,0 +1,21 @@
+// Package lru provides three different LRU caches of varying sophistication.
+//
+// Cache is a simple LRU cache. It is based on the
+// LRU implementation in groupcache:
+// https://github.com/golang/groupcache/tree/master/lru
+//
+// TwoQueueCache tracks frequently used and recently used entries separately.
+// This avoids a burst of accesses from taking out frequently used entries,
+// at the cost of about 2x computational overhead and some extra bookkeeping.
+//
+// ARCCache is an adaptive replacement cache. It tracks recent evictions as
+// well as recent usage in both the frequent and recent caches. Its
+// computational overhead is comparable to TwoQueueCache, but the memory
+// overhead is linear with the size of the cache.
+//
+// ARC has been patented by IBM, so do not use it if that is problematic for
+// your program.
+//
+// All caches in this package take locks while operating, and are therefore
+// thread-safe for consumers.
+package lru

--- a/vendor/github.com/hashicorp/golang-lru/go.mod
+++ b/vendor/github.com/hashicorp/golang-lru/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/golang-lru
+
+go 1.12

--- a/vendor/github.com/hashicorp/golang-lru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/lru.go
@@ -1,0 +1,231 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+const (
+	// DefaultEvictedBufferSize defines the default buffer size to store evicted key/val
+	DefaultEvictedBufferSize = 16
+)
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	lru                      *simplelru.LRU
+	evictedKeys, evictedVals []interface{}
+	onEvictedCB              func(k, v interface{})
+	lock                     sync.RWMutex
+}
+
+// New creates an LRU of the given size.
+func New(size int) (*Cache, error) {
+	return NewWithEvict(size, nil)
+}
+
+// NewWithEvict constructs a fixed size cache with the given eviction
+// callback.
+func NewWithEvict(size int, onEvicted func(key, value interface{})) (c *Cache, err error) {
+	// create a cache with default settings
+	c = &Cache{
+		onEvictedCB: onEvicted,
+	}
+	if onEvicted != nil {
+		c.initEvictBuffers()
+		onEvicted = c.onEvicted
+	}
+	c.lru, err = simplelru.NewLRU(size, onEvicted)
+	return
+}
+
+func (c *Cache) initEvictBuffers() {
+	c.evictedKeys = make([]interface{}, 0, DefaultEvictedBufferSize)
+	c.evictedVals = make([]interface{}, 0, DefaultEvictedBufferSize)
+}
+
+// onEvicted save evicted key/val and sent in externally registered callback
+// outside of critical section
+func (c *Cache) onEvicted(k, v interface{}) {
+	c.evictedKeys = append(c.evictedKeys, k)
+	c.evictedVals = append(c.evictedVals, v)
+}
+
+// Purge is used to completely clear the cache.
+func (c *Cache) Purge() {
+	var ks, vs []interface{}
+	c.lock.Lock()
+	c.lru.Purge()
+	if c.onEvictedCB != nil && len(c.evictedKeys) > 0 {
+		ks, vs = c.evictedKeys, c.evictedVals
+		c.initEvictBuffers()
+	}
+	c.lock.Unlock()
+	// invoke callback outside of critical section
+	if c.onEvictedCB != nil {
+		for i := 0; i < len(ks); i++ {
+			c.onEvictedCB(ks[i], vs[i])
+		}
+	}
+}
+
+// Add adds a value to the cache. Returns true if an eviction occurred.
+func (c *Cache) Add(key, value interface{}) (evicted bool) {
+	var k, v interface{}
+	c.lock.Lock()
+	evicted = c.lru.Add(key, value)
+	if c.onEvictedCB != nil && evicted {
+		k, v = c.evictedKeys[0], c.evictedVals[0]
+		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && evicted {
+		c.onEvictedCB(k, v)
+	}
+	return
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	value, ok = c.lru.Get(key)
+	c.lock.Unlock()
+	return value, ok
+}
+
+// Contains checks if a key is in the cache, without updating the
+// recent-ness or deleting it for being stale.
+func (c *Cache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	containKey := c.lru.Contains(key)
+	c.lock.RUnlock()
+	return containKey
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *Cache) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.RLock()
+	value, ok = c.lru.Peek(key)
+	c.lock.RUnlock()
+	return value, ok
+}
+
+// ContainsOrAdd checks if a key is in the cache without updating the
+// recent-ness or deleting it for being stale, and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evicted bool) {
+	var k, v interface{}
+	c.lock.Lock()
+	if c.lru.Contains(key) {
+		c.lock.Unlock()
+		return true, false
+	}
+	evicted = c.lru.Add(key, value)
+	if c.onEvictedCB != nil && evicted {
+		k, v = c.evictedKeys[0], c.evictedVals[0]
+		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && evicted {
+		c.onEvictedCB(k, v)
+	}
+	return false, evicted
+}
+
+// PeekOrAdd checks if a key is in the cache without updating the
+// recent-ness or deleting it for being stale, and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *Cache) PeekOrAdd(key, value interface{}) (previous interface{}, ok, evicted bool) {
+	var k, v interface{}
+	c.lock.Lock()
+	previous, ok = c.lru.Peek(key)
+	if ok {
+		c.lock.Unlock()
+		return previous, true, false
+	}
+	evicted = c.lru.Add(key, value)
+	if c.onEvictedCB != nil && evicted {
+		k, v = c.evictedKeys[0], c.evictedVals[0]
+		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && evicted {
+		c.onEvictedCB(k, v)
+	}
+	return nil, false, evicted
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key interface{}) (present bool) {
+	var k, v interface{}
+	c.lock.Lock()
+	present = c.lru.Remove(key)
+	if c.onEvictedCB != nil && present {
+		k, v = c.evictedKeys[0], c.evictedVals[0]
+		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && present {
+		c.onEvictedCB(k, v)
+	}
+	return
+}
+
+// Resize changes the cache size.
+func (c *Cache) Resize(size int) (evicted int) {
+	var ks, vs []interface{}
+	c.lock.Lock()
+	evicted = c.lru.Resize(size)
+	if c.onEvictedCB != nil && evicted > 0 {
+		ks, vs = c.evictedKeys, c.evictedVals
+		c.initEvictBuffers()
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && evicted > 0 {
+		for i := 0; i < len(ks); i++ {
+			c.onEvictedCB(ks[i], vs[i])
+		}
+	}
+	return evicted
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() (key, value interface{}, ok bool) {
+	var k, v interface{}
+	c.lock.Lock()
+	key, value, ok = c.lru.RemoveOldest()
+	if c.onEvictedCB != nil && ok {
+		k, v = c.evictedKeys[0], c.evictedVals[0]
+		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && ok {
+		c.onEvictedCB(k, v)
+	}
+	return
+}
+
+// GetOldest returns the oldest entry
+func (c *Cache) GetOldest() (key, value interface{}, ok bool) {
+	c.lock.RLock()
+	key, value, ok = c.lru.GetOldest()
+	c.lock.RUnlock()
+	return
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *Cache) Keys() []interface{} {
+	c.lock.RLock()
+	keys := c.lru.Keys()
+	c.lock.RUnlock()
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	length := c.lru.Len()
+	c.lock.RUnlock()
+	return length
+}

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -1,0 +1,177 @@
+package simplelru
+
+import (
+	"container/list"
+	"errors"
+)
+
+// EvictCallback is used to get a callback when a cache entry is evicted
+type EvictCallback func(key interface{}, value interface{})
+
+// LRU implements a non-thread safe fixed size LRU cache
+type LRU struct {
+	size      int
+	evictList *list.List
+	items     map[interface{}]*list.Element
+	onEvict   EvictCallback
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key   interface{}
+	value interface{}
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
+	if size <= 0 {
+		return nil, errors.New("must provide a positive size")
+	}
+	c := &LRU{
+		size:      size,
+		evictList: list.New(),
+		items:     make(map[interface{}]*list.Element),
+		onEvict:   onEvict,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache.
+func (c *LRU) Purge() {
+	for k, v := range c.items {
+		if c.onEvict != nil {
+			c.onEvict(k, v.Value.(*entry).value)
+		}
+		delete(c.items, k)
+	}
+	c.evictList.Init()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *LRU) Add(key, value interface{}) (evicted bool) {
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*entry).value = value
+		return false
+	}
+
+	// Add new item
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	evict := c.evictList.Len() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		if ent.Value.(*entry) == nil {
+			return nil, false
+		}
+		return ent.Value.(*entry).value, true
+	}
+	return
+}
+
+// Contains checks if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *LRU) Contains(key interface{}) (ok bool) {
+	_, ok = c.items[key]
+	return ok
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+	var ent *list.Element
+	if ent, ok = c.items[key]; ok {
+		return ent.Value.(*entry).value, true
+	}
+	return nil, ok
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU) Remove(key interface{}) (present bool) {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *LRU) RemoveOldest() (key, value interface{}, ok bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// GetOldest returns the oldest entry
+func (c *LRU) GetOldest() (key, value interface{}, ok bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *LRU) Keys() []interface{} {
+	keys := make([]interface{}, len(c.items))
+	i := 0
+	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
+		keys[i] = ent.Value.(*entry).key
+		i++
+	}
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *LRU) Len() int {
+	return c.evictList.Len()
+}
+
+// Resize changes the cache size.
+func (c *LRU) Resize(size int) (evicted int) {
+	diff := c.Len() - size
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		c.removeOldest()
+	}
+	c.size = size
+	return diff
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.items, kv.key)
+	if c.onEvict != nil {
+		c.onEvict(kv.key, kv.value)
+	}
+}

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
@@ -1,0 +1,40 @@
+// Package simplelru provides simple LRU implementation based on build-in container/list.
+package simplelru
+
+// LRUCache is the interface for simple LRU cache.
+type LRUCache interface {
+	// Adds a value to the cache, returns true if an eviction occurred and
+	// updates the "recently used"-ness of the key.
+	Add(key, value interface{}) bool
+
+	// Returns key's value from the cache and
+	// updates the "recently used"-ness of the key. #value, isFound
+	Get(key interface{}) (value interface{}, ok bool)
+
+	// Checks if a key exists in cache without updating the recent-ness.
+	Contains(key interface{}) (ok bool)
+
+	// Returns key's value without updating the "recently used"-ness of the key.
+	Peek(key interface{}) (value interface{}, ok bool)
+
+	// Removes a key from the cache.
+	Remove(key interface{}) bool
+
+	// Removes the oldest entry from cache.
+	RemoveOldest() (interface{}, interface{}, bool)
+
+	// Returns the oldest entry from the cache. #key, value, isFound
+	GetOldest() (interface{}, interface{}, bool)
+
+	// Returns a slice of the keys in the cache, from oldest to newest.
+	Keys() []interface{}
+
+	// Returns the number of items in the cache.
+	Len() int
+
+	// Clears all cache entries.
+	Purge()
+
+	// Resizes cache, returning number evicted
+	Resize(int) int
+}

--- a/vendor/github.com/hashicorp/golang-lru/testing.go
+++ b/vendor/github.com/hashicorp/golang-lru/testing.go
@@ -1,0 +1,16 @@
+package lru
+
+import (
+	"crypto/rand"
+	"math"
+	"math/big"
+	"testing"
+)
+
+func getRand(tb testing.TB) int64 {
+	out, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return out.Int64()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,6 @@
+# github.com/hashicorp/golang-lru v1.0.2
+github.com/hashicorp/golang-lru
+github.com/hashicorp/golang-lru/simplelru
 # github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31
 github.com/rogpeppe/go-charset/charset
 github.com/rogpeppe/go-charset/data


### PR DESCRIPTION
## Problem

`goproxy` supports HTTPS MITM mode by dynamically generating a per-host leaf TLS certificate, signing it with the configured MITM CA, and presenting that certificate to the client.

The security expectation is that the generated leaf certificate’s private key is unpredictable. The CA private key should only be used to sign the leaf certificate.

Before this change, `signHost` generated the leaf private key using a custom deterministic reader:

```go
csprng, err := NewCounterEncryptorRandFromKey(ca.PrivateKey, hash)
rsa.GenerateKey(&csprng, 2048)
x509.CreateCertificate(&csprng, ...)
```
That reader intended to derive an AES-CTR stream by hashing the CA private key bytes and a host seed. However, it used Go’s hash API incorrectly:

```go
h := sha256.New()
h.Sum(keyBytes)
h.Sum(seed)
```
Hash.Sum(b) does not hash b; it appends the current digest to b. Since nothing was written into the hash, this effectively used:

```
keyBytes[:16]
seed[:16]
```
as the AES key/counter material.

For an RSA private key encoded as PKCS#1 DER, the first bytes are mostly ASN.1 structure plus public RSA modulus bytes. Much of that can be reconstructed from the public CA certificate. The
seed is also public/guessable because it is based on hostname, signer version, and Go runtime version.

That made MITM leaf-key generation potentially predictable from public or guessable inputs.

This affects users of goproxy MITM certificate generation, when MITM mode is enabled. Normal CONNECT tunneling is not affected.

## Solution

This change fixes the issue in three parts.

1. Use real cryptographic randomness for MITM leaf certificates.

signHost now uses crypto/rand.Reader for:

rsa.GenerateKey(rand.Reader, 2048)
x509.CreateCertificate(rand.Reader, ...)

It also generates random positive certificate serial numbers using rand.Int.

2. Fix the exported counter encryptor helper.

NewCounterEncryptorRandFromKey now uses:

sha256.Sum256(keyBytes)
sha256.Sum256(seed)

instead of h.Sum(...).

Even though MITM signing no longer uses this helper, it is exported and should not retain the hash misuse.

3. Add bounded certificate caching.

Because leaf keys are now truly random, repeated calls for the same host would otherwise generate a new RSA key every time. To avoid unnecessary CPU/latency, TLSConfigFromCA now uses a bounded
per-CA cache.

Defaults:

DefaultMITMCertCacheMaxEntries = 4096
DefaultMITMCertCacheTTL        = time.Hour

A new helper, TLSConfigFromCAWithCache, allows callers to tune or disable caching.

## Why This Works

The vulnerability came from using predictable deterministic bytes as the randomness source for RSA key generation.

After this change, MITM leaf private keys are generated from the OS CSPRNG via crypto/rand.Reader. Someone with the public CA certificate, hostname, Go runtime version, or signer version can
no longer reproduce the leaf private key.

The CA private key is now only used for its intended purpose: signing the generated leaf certificate.

The cache preserves performance without reintroducing predictability. It stores already-generated random certificates per stripped hostname, bounded by LRU size and TTL. Hostname-driven memory
growth is capped.

## What Changed

  - signer.go
      - Removed deterministic host/Go-version seed logic.
      - Removed use of CounterEncryptorRand in MITM signing.
      - Uses crypto/rand.Reader for RSA key generation and certificate creation.
      - Uses random positive serial numbers.

  - counterecryptor.go
      - Replaced incorrect h.Sum(keyBytes) / h.Sum(seed) usage with sha256.Sum256.

  - https.go
      - Added internal bounded LRU + TTL MITM certificate cache.
      - TLSConfigFromCA now uses default cache settings.
      - Added TLSConfigFromCAWithCache for custom cache size/TTL or disabling cache.

  - counterecryptor_test.go
      - Added regression coverage proving key/seed are SHA-256-derived, not raw prefixes.

  - signer_test.go
      - Added tests for random leaf private keys and serials.
      - Added tests for cache reuse, LRU eviction, TTL expiry, and disabled caching.
      
### Testing
```
  go test . -run 'TestCounterEncUsesSHA256KeyAndSeed|TestSignHostGeneratesRandomLeafPrivateKey|TestTLSConfigFromCACachesHostCertificates|TestTLSConfigFromCACacheCanBeDisabled|TestMITMCertCache'
  -count=1
  go test ./...
  git -c core.fsmonitor=false diff --check
  ```